### PR TITLE
Move note about sudoers.

### DIFF
--- a/adoc/shared.adoc
+++ b/adoc/shared.adoc
@@ -10,8 +10,8 @@ This change affects all new installations and upgraded systems that did not chan
 This has several consequences:
 
 * files created by new users are not group-readable by default
-* configurations that used the primary `users` group as a condition do not work anymore, for example, `@users` in the sudoers file
-* configurations that used the primary or secondary `users` group as a condition need to have the `users` group manually added to theses user accounts in order to continue to work
+* configurations that used the primary `users` group as a condition do not work anymore
+* configurations that used the primary or secondary `users` group as a condition need to have the `users` group manually added to these user accounts in order to continue to work, for example, to for `@users` in the sudoers file
 * home directories inherited from a previous system need to standardize the GID of the files by running: `find "$HOME" -group users -exec chgrp myuser {} \;`, or `chgrp -R myuser "$HOME"` if you did not use any GID other than `users`
 end::bsc1240989[]
 


### PR DESCRIPTION
The example of sudoers is in the bad section. sudo respects secondary groups as well, so it belongs one line lower.