### PR TITLE
SLES 16.0: Add aarch64 section and share contents with SL Micro 6.2

### DIFF
--- a/adoc/kernel-160-aarch64.adoc
+++ b/adoc/kernel-160-aarch64.adoc
@@ -1,0 +1,39 @@
+[#arm64-soc]
+= System-on-Chip driver enablement
+
+{productnameshort} {this-version} includes driver enablement for the following
+System-on-Chip (SoC) chipsets:
+
+// * {amdreg} {opteronreg} A1100
+* {amperereg} {xgenereg}, {emagreg}, {altrareg}, _{altramax}_, {ampereonereg}
+* {awsreg} Graviton, Graviton2, Graviton3
+* {brcmreg} BCM2837/BCM2710, BCM2711
+* {fujitsureg} A64FX
+* {huaweireg} {kunpengreg} 916, {kunpeng} 920
+* {marvellreg} {thunderxreg}, {thunderx2reg}; {octeon-txreg}; {armadareg} 7040, {armada} 8040
+// jsc#PED-8032 (BF3)
+* {nvidiareg} {grace}; {tegrareg}{nbsp}X1, Tegra{nbsp}X2, {xavierreg}, {orin}; {bluefieldreg}, _{bluefield2}_, _{bluefield3}_
+// jsc#SLE-12251 (LS1012A), jsc#SLE-11914 (i.MX 8MM)
+* {nxpreg} {imx} 8M, 8M{nbsp}Mini; {layerscapereg} LS1012A, LS1027A/LS1017A, LS1028A/LS1018A, LS1043A, LS1046A, LS1088A, LS2080A/LS2040A, LS2088A, LX2160A
+// * {qcomreg} {centriqreg} 2400
+* Rockchip RK3399
+* {socionextreg} {synquacerreg} SC2A11
+* {xilinxreg} {zynqreg} {ultrascalereg}{nbzwsp}+ MPSoC
+
+NOTE: Driver enablement is done as far as available and requested.
+Refer to the following sections for any known limitations.
+
+Some systems might need additional drivers for external chips, such as a
+Power Management Integrated Chip (PMIC), which may differ between systems
+with the same SoC chipset.
+
+For booting, systems need to fulfill either the Server Base Boot Requirements (SBBR)
+or the Embedded Base Boot Requirements (EBBR),
+that is, the Unified Extensible Firmware Interface (UEFI) either
+implementing the Advanced Configuration and Power Interface (ACPI) or
+providing a Flat Device Tree (FDT) table. If both are implemented, the kernel
+will default to the Device Tree; the kernel command line argument `acpi=force` can
+override this default behavior.
+
+Check for {suse} _YES!_ certified systems,
+which have undergone compatibility testing.

--- a/adoc/micro/version62.adoc
+++ b/adoc/micro/version62.adoc
@@ -36,6 +36,11 @@ include::../shared.adoc[tags=bsc1240989,leveloffset=+3]
 
 include::shared.adoc[tags=62,leveloffset=+3]
 
+[#aarch64]
+=== {arm} 64-bit-specific features and fixes ({aarch64})
+
+include::../kernel-160-aarch64.adoc[leveloffset=+3]
+
 // === Removed and deprecated features and packages
 
 // [#removed]

--- a/adoc/sles/version160.adoc
+++ b/adoc/sles/version160.adoc
@@ -355,6 +355,11 @@ KVM in a PowerVM LPAR is a new type of LPAR (logical partition) that allows the 
 A KVM enabled LPAR allows standard Linux KVM tools (for example, `virsh`) to create and manage lightweight Linux Virtual Machines (VM).
 A KVM Linux LPAR uses dedicated cores which enables Linux to have full control of when Linux VMs are scheduled to run, just like KVM on other platforms.
 
+[#aarch64]
+=== {arm}-specific changes ({aarch64})
+
+include::../kernel-160-aarch64.adoc[leveloffset=+3]
+
 [#virtualization]
 === Virtualization
 


### PR DESCRIPTION
Prepare AArch64 sections for SLES 16.0 and SL Micro 6.2.
Share initial contents copied from SL Micro 6.0/6.1.