### PR TITLE
SL Micro 6.x: Document evolving aarch64 console settings and images

### DIFF
--- a/adoc/common/aarch64-console.adoc
+++ b/adoc/common/aarch64-console.adoc
@@ -1,0 +1,14 @@
+[NOTE]
+.System default console settings
+====
+System firmware can use two methods for specifying a default console device:
+
+* ACPI Serial Port Console Redirection (SPCR) table.
+This ACPI table may be configurable via system firmware setup menus.
+* FDT `/chosen/stdout-path` property.
+This FDT property may be adjustable, for example, by applying FDT Overlays.
+
+These defaults get overridden by using any `console=` kernel command line options.
+Adding a secondary output device therefore requires manually specifying the
+default console device.
+====

--- a/adoc/micro/version60.adoc
+++ b/adoc/micro/version60.adoc
@@ -231,6 +231,22 @@ Information in this section applies to {productnameshort} {this-version}.
 
 include::kernel-micro-60-aarch64.adoc[]
 
+[#bsc-1229336]
+=== Default console settings optimized for {rpi}
+
+The {productnameshort} {this-version} {aarch64} images use default kernel
+command line settings tuned for easy evaluation on {rpireg} devices.
+
+For usage with {arm} BSA-compliant servers you will have to edit the
+command line in the GRUB menu:
+
+* Drop `console=ttyS0,115200`. Optionally try `console=ttyAMA0,115200` or similar for serial output, including IPMI Serial-over-LAN via a BMC.
+* Drop `console=tty0` if you don't need the console output on a graphical display.
+
+This behavior will change with {productnameshort} {next-version}.
+
+include::../common/aarch64-console.adoc[]
+
 // :leveloffset: +1
 
 

--- a/adoc/micro/version61.adoc
+++ b/adoc/micro/version61.adoc
@@ -72,6 +72,26 @@ include::shared.adoc[tags=61,leveloffset=+3]
 
 include::kernel-micro-60-aarch64.adoc[leveloffset=+1]
 
+[#bsc-1229336]
+==== Changed default console settings optimized for servers
+
+{productnameshort} {previous-version} used default kernel command line
+console settings optimized for {rpireg} devices. This allowed for a
+convenient evaluation on those devices but led to problems and the need for
+configuration changes when deploying to other machines.
+
+{productnameshort} {this-version} uses default kernel command line
+settings optimized for standards-compliant devices:
+
+* For console output on the {rpi} GPIO header you may need to specify
+`console=ttyS0,115200n8` in the GRUB menu.
+* For console output on a graphical display you may need to add
+`console=tty0`.
+* You may need to configure your system firmware to default output to your
+preferred location.
+
+include::../common/aarch64-console.adoc[]
+
 === Removed and deprecated features and packages
 
 // This section is intended as a quick-to-consume list of deprecations/removals

--- a/adoc/micro/version62.adoc
+++ b/adoc/micro/version62.adoc
@@ -57,6 +57,19 @@ systems with large RAM and big data workloads.
 Only these contain the firmware, partition table and default console
 kernel command line settings for booting on {rpi} devices.
 
+[#bsc-1229336]
+==== Default console settings
+
+{productnameshort} {this-version} uses default kernel command line
+settings optimized for standards-compliant devices:
+
+* For console output on a graphical display you may need to add
+`console=tty0`.
+* You may need to configure your system firmware to default output to your
+preferred location.
+
+include::../common/aarch64-console.adoc[]
+
 === Removed and deprecated features and packages
 
 // [#removed]

--- a/adoc/micro/version62.adoc
+++ b/adoc/micro/version62.adoc
@@ -41,6 +41,14 @@ include::shared.adoc[tags=62,leveloffset=+3]
 
 include::../kernel-160-aarch64.adoc[leveloffset=+3]
 
+[#jsc-PED-8758]
+==== New 64{nbsp}KiB page size images
+
+{productname} {this-version} introduces `64kb` images.
+These provide the `64kb` kernel flavor with 64{nbsp}KiB page size preinstalled.
+They are primarily intended for {nvidiareg} {grace} platform or other
+systems with large RAM and big data workloads.
+
 === Removed and deprecated features and packages
 
 // [#removed]

--- a/adoc/micro/version62.adoc
+++ b/adoc/micro/version62.adoc
@@ -49,6 +49,14 @@ These provide the `64kb` kernel flavor with 64{nbsp}KiB page size preinstalled.
 They are primarily intended for {nvidiareg} {grace} platform or other
 systems with large RAM and big data workloads.
 
+// [#bsc-1240619]
+[#jsc-PED-12522]
+==== New {rpi} images (RC1)
+
+{productname} {this-version} introduces separate `RaspberryPi` images.
+Only these contain the firmware, partition table and default console
+kernel command line settings for booting on {rpi} devices.
+
 === Removed and deprecated features and packages
 
 // [#removed]


### PR DESCRIPTION
* Document Micro 6.0 console defaults
* Document Micro 6.1 console default changes (bsc#1229336)
* Document Micro 6.2 image changes (jsc#PED-8758, jsc#PED-12522) and console defaults