### PR TITLE
Changes related to generic info (BZ link, product names)

### DIFF
--- a/adoc/sleha/release-notes-sleha-160-docinfo.xml
+++ b/adoc/sleha/release-notes-sleha-160-docinfo.xml
@@ -7,6 +7,6 @@
    </dm:bugtracker>
   </dm:docmanager>
   <releaseinfo>@VERSION@</releaseinfo>
-  <productname>SUSE Linux Enterprise Server</productname>
+  <productname>SUSE Linux Enterprise High Availability</productname>
   <productnumber>16.0</productnumber>
   <date><?dbtimestamp format="Y-m-d"?></date>

--- a/adoc/slesap/attributes.adoc
+++ b/adoc/slesap/attributes.adoc
@@ -1,5 +1,5 @@
-:productname: SUSE Linux Enterprise Server for SAP Applications
-:productnameshort: SLE-SAP
+:productname: SUSE Linux Enterprise Server for SAP applications
+:productnameshort: SLES for SAP
 :rel-date: TBD
 
 :power-productname: {productname} for POWER

--- a/adoc/slesap/release-notes-slesap-160-docinfo.xml
+++ b/adoc/slesap/release-notes-slesap-160-docinfo.xml
@@ -2,11 +2,11 @@
    <dm:bugtracker>
     <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
     <dm:component>Release Notes</dm:component>
-    <dm:product>SUSE Linux Enterprise High Availability 16.0</dm:product>
+    <dm:product>SUSE Linux Enterprise Server for SAP Applications 16.0</dm:product>
     <dm:assignee>lukas.kucharczyk@suse.com</dm:assignee>
    </dm:bugtracker>
   </dm:docmanager>
   <releaseinfo>@VERSION@</releaseinfo>
-  <productname>SUSE Linux Enterprise Server</productname>
+  <productname>SUSE Linux Enterprise Server for SAP applications</productname>
   <productnumber>16.0</productnumber>
   <date><?dbtimestamp format="Y-m-d"?></date>


### PR DESCRIPTION
Some smaller issues I noticed when looking at the RN previews.

- SLES for SAP RN had wrong Bugzilla link (pointing to SLE HA instead)
- all RN have the same `<productname>` set, namely 'SUSE Linux Enterprise Server' - I would suggest to change that to the actual product names for the RN for SLES for SAP and SLE HA 
- According to a recent change request, the official spelling we use for 'SUSE Linux Enterprise for SAP Applications' is with a small 'a' for 'applications' now, and the short name has been updated to 'SLES for SAP' (as per our Terminology Database)    