### PR TITLE
CI: Enable release notes preview builds on pull requests

### DIFF
--- a/.github/workflows/asciidoc.yml
+++ b/.github/workflows/asciidoc.yml
@@ -90,6 +90,7 @@ jobs:
     permissions:
       pull-requests: write
       issues: write
+      contents: write
     needs: build
     continue-on-error: true
     steps:
@@ -122,18 +123,36 @@ jobs:
           mv "$OUTPUT_DIR/html/releasenotes_sles_16.1"/* publish/preview/sles-16.1/html/release-notes
           mv "$OUTPUT_DIR/html/releasenotes_sles-sap_16.0"/* publish/preview/slesap-16.0/html/release-notes
           mv "$OUTPUT_DIR/html/releasenotes_sles-sap_16.1"/* publish/preview/slesap-16.1/html/release-notes
-          echo '<meta http-equiv="refresh" content="0;https://suse.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/sles-16.0/html/release-notes/">' > publish/preview/sles-16_SP0/html/release-notes/index.html
+          echo '<meta http-equiv="refresh" content="0;https://suse.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sles-16.0/html/release-notes/">' > publish/preview/sles-16_SP0/html/release-notes/index.html
           rm -rf artifact-dir
           mv publish artifact-dir
-      - name: Publishing preview on local github pages
-        uses: SUSE/release-notes@gha-publish
-        env:
-          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
-        with:
-          artifact-path:  artifact-dir
-          publish-repo: gh:${{ github.repository }}.git
-          repo-reset-after: 0
-          branchless: "false"
+      - name: Deploy preview to local gh-pages
+        run: |
+          git config --global user.name "SUSE Docs Bot"
+          git config --global user.email "doc-team+docbot@suse.com"
+          
+          git clone --branch gh-pages https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git local-gh-pages || {
+            git clone https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git local-gh-pages
+            cd local-gh-pages
+            git checkout --orphan gh-pages
+            git rm -rf .
+            cd ..
+          }
+          
+          mypubdir="local-gh-pages/refs,pull,${{ github.event.pull_request.number }},merge"
+          rm -rf "$mypubdir"
+          mkdir -p "$mypubdir"
+          cp -r artifact-dir/preview/* "$mypubdir/"
+          touch local-gh-pages/.nojekyll
+          
+          cd local-gh-pages
+          git add -A .
+          if git diff-index --quiet HEAD --; then
+            echo "No changes to deploy."
+          else
+            git commit -m "Deploy preview for PR #${{ github.event.pull_request.number }}"
+            git push origin gh-pages
+          fi
       - name: Comment on PR with preview link
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -144,19 +163,19 @@ jobs:
           body="🚀 **Release Notes Preview is ready!**
 
           You can preview the built release notes here:
-          - [SLES 16.1](https://suse.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/sles-16.1/html/release-notes/)
-          - [SLES 16.0](https://suse.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/sles-16.0/html/release-notes/)
-          - [SLE HA 16.1](https://suse.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/sleha-16.1/html/release-notes/)
-          - [SLE HA 16.0](https://suse.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/sleha-16.0/html/release-notes/)
-          - [SLES for SAP 16.1](https://suse.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/slesap-16.1/html/release-notes/)
-          - [SLES for SAP 16.0](https://suse.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/slesap-16.0/html/release-notes/)
-          - [openSUSE Leap 16.1](https://suse.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/leap-16.1/html/release-notes/)
-          - [openSUSE Leap 16.0](https://suse.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/leap-16.0/html/release-notes/)
-          - [SLE Micro 6.2](https://suse.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/sl-micro_62/html/release-notes/)
-          - [SLE Micro 6.1](https://suse.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/sl-micro_61/html/release-notes/)
-          - [SLE Micro 6.0](https://suse.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/sl-micro_60/html/release-notes/)
+          - [SLES 16.1](https://suse.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sles-16.1/html/release-notes/)
+          - [SLES 16.0](https://suse.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sles-16.0/html/release-notes/)
+          - [SLE HA 16.1](https://suse.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sleha-16.1/html/release-notes/)
+          - [SLE HA 16.0](https://suse.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sleha-16.0/html/release-notes/)
+          - [SLES for SAP 16.1](https://suse.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/slesap-16.1/html/release-notes/)
+          - [SLES for SAP 16.0](https://suse.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/slesap-16.0/html/release-notes/)
+          - [openSUSE Leap 16.1](https://suse.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/leap-16.1/html/release-notes/)
+          - [openSUSE Leap 16.0](https://suse.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/leap-16.0/html/release-notes/)
+          - [SLE Micro 6.2](https://suse.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sl-micro_62/html/release-notes/)
+          - [SLE Micro 6.1](https://suse.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sl-micro_61/html/release-notes/)
+          - [SLE Micro 6.0](https://suse.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sl-micro_60/html/release-notes/)
 
-          Directory Index: https://suse.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/"
+          Directory Index: https://suse.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/"
 
           if [ -n "$comment_id" ]; then
             gh api -X PATCH "repos/${{ github.repository }}/issues/comments/$comment_id" -f body="$body"

--- a/.github/workflows/asciidoc.yml
+++ b/.github/workflows/asciidoc.yml
@@ -23,7 +23,6 @@ jobs:
           validate-tables: true
   build:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
     needs: validate
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/asciidoc.yml
+++ b/.github/workflows/asciidoc.yml
@@ -121,16 +121,16 @@ jobs:
           mv "$OUTPUT_DIR/html/releasenotes_sles_16.1"/* publish/preview/sles-16.1/html/release-notes
           mv "$OUTPUT_DIR/html/releasenotes_sles-sap_16.0"/* publish/preview/slesap-16.0/html/release-notes
           mv "$OUTPUT_DIR/html/releasenotes_sles-sap_16.1"/* publish/preview/slesap-16.1/html/release-notes
-          echo '<meta http-equiv="refresh" content="0;https://susedoc.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/sles-16.0/html/release-notes/">' > publish/preview/sles-16_SP0/html/release-notes/index.html
+          echo '<meta http-equiv="refresh" content="0;https://suse.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/sles-16.0/html/release-notes/">' > publish/preview/sles-16_SP0/html/release-notes/index.html
           rm -rf artifact-dir
           mv publish artifact-dir
-      - name: Publishing preview on susedoc.github.io
+      - name: Publishing preview on local github pages
         uses: SUSE/release-notes@gha-publish
         env:
           DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
         with:
           artifact-path:  artifact-dir
-          publish-repo: gh:SUSEdoc/release-notes.git
+          publish-repo: gh:${{ github.repository }}.git
           repo-reset-after: 0
           branchless: "false"
       - name: Comment on PR with preview link
@@ -143,19 +143,19 @@ jobs:
           body="🚀 **Release Notes Preview is ready!**
 
           You can preview the built release notes here:
-          - [SLES 16.1](https://susedoc.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/sles-16.1/html/release-notes/)
-          - [SLES 16.0](https://susedoc.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/sles-16.0/html/release-notes/)
-          - [SLE HA 16.1](https://susedoc.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/sleha-16.1/html/release-notes/)
-          - [SLE HA 16.0](https://susedoc.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/sleha-16.0/html/release-notes/)
-          - [SLES for SAP 16.1](https://susedoc.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/slesap-16.1/html/release-notes/)
-          - [SLES for SAP 16.0](https://susedoc.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/slesap-16.0/html/release-notes/)
-          - [openSUSE Leap 16.1](https://susedoc.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/leap-16.1/html/release-notes/)
-          - [openSUSE Leap 16.0](https://susedoc.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/leap-16.0/html/release-notes/)
-          - [SLE Micro 6.2](https://susedoc.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/sl-micro_62/html/release-notes/)
-          - [SLE Micro 6.1](https://susedoc.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/sl-micro_61/html/release-notes/)
-          - [SLE Micro 6.0](https://susedoc.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/sl-micro_60/html/release-notes/)
+          - [SLES 16.1](https://suse.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/sles-16.1/html/release-notes/)
+          - [SLES 16.0](https://suse.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/sles-16.0/html/release-notes/)
+          - [SLE HA 16.1](https://suse.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/sleha-16.1/html/release-notes/)
+          - [SLE HA 16.0](https://suse.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/sleha-16.0/html/release-notes/)
+          - [SLES for SAP 16.1](https://suse.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/slesap-16.1/html/release-notes/)
+          - [SLES for SAP 16.0](https://suse.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/slesap-16.0/html/release-notes/)
+          - [openSUSE Leap 16.1](https://suse.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/leap-16.1/html/release-notes/)
+          - [openSUSE Leap 16.0](https://suse.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/leap-16.0/html/release-notes/)
+          - [SLE Micro 6.2](https://suse.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/sl-micro_62/html/release-notes/)
+          - [SLE Micro 6.1](https://suse.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/sl-micro_61/html/release-notes/)
+          - [SLE Micro 6.0](https://suse.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/sl-micro_60/html/release-notes/)
 
-          Directory Index: https://susedoc.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/"
+          Directory Index: https://suse.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/"
 
           if [ -n "$comment_id" ]; then
             gh api -X PATCH "repos/${{ github.repository }}/issues/comments/$comment_id" -f body="$body"

--- a/.github/workflows/asciidoc.yml
+++ b/.github/workflows/asciidoc.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "DC-*"
       - "adoc/**"
+      - ".github/workflows/*"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/asciidoc.yml
+++ b/.github/workflows/asciidoc.yml
@@ -140,7 +140,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Find existing comment to avoid duplicate comments
-          comment_id=$(gh pr view ${{ github.event.pull_request.number }} --json comments --jq '.comments[] | select(.body | contains("Release Notes Preview is ready!")) | .id' | head -n1)
+          comment_id=$(gh pr view ${{ github.event.pull_request.number }} --json comments --jq '.comments[] | select(.body | contains("Release Notes Preview is ready!")) | .url' | grep -oP '\d+$' | head -n1)
           
           body="🚀 **Release Notes Preview is ready!**
 

--- a/.github/workflows/asciidoc.yml
+++ b/.github/workflows/asciidoc.yml
@@ -82,3 +82,83 @@ jobs:
           publish-repo: gh:SUSEdoc/release-notes.git
           repo-reset-after: 35
           branchless: "true"
+
+  preview:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: write
+      issues: write
+    needs: build
+    continue-on-error: true
+    steps:
+      - name: Downloading all build artifacts
+        id: download-artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifact-dir
+      - name: Create folder hierarchy for preview
+        run: |
+          mkdir -p publish/preview/sl-micro{_60,_61,_62}/html/release-notes
+          mkdir -p publish/preview/sles-16.0/html/release-notes
+          mkdir -p publish/preview/sles-16.1/html/release-notes
+          mkdir -p publish/preview/sleha-16.0/html/release-notes
+          mkdir -p publish/preview/sleha-16.1/html/release-notes
+          mkdir -p publish/preview/slesap-16.0/html/release-notes
+          mkdir -p publish/preview/slesap-16.1/html/release-notes
+          mkdir -p publish/preview/sles-16_SP0/html/release-notes
+          mkdir -p publish/preview/leap-16.0/html/release-notes
+          mkdir -p publish/preview/leap-16.1/html/release-notes
+          OUTPUT_DIR=$(find artifact-dir -mindepth 1 -maxdepth 1 -type d)
+          mv "$OUTPUT_DIR/html/releasenotes_leap_16.0"/* publish/preview/leap-16.0/html/release-notes
+          mv "$OUTPUT_DIR/html/releasenotes_leap_16.1"/* publish/preview/leap-16.1/html/release-notes
+          mv "$OUTPUT_DIR/html/releasenotes_sle-ha_16.0"/* publish/preview/sleha-16.0/html/release-notes
+          mv "$OUTPUT_DIR/html/releasenotes_sle-ha_16.1"/* publish/preview/sleha-16.1/html/release-notes
+          mv "$OUTPUT_DIR/html/releasenotes_sle-micro_6.0"/* publish/preview/sl-micro_60/html/release-notes
+          mv "$OUTPUT_DIR/html/releasenotes_sle-micro_6.1"/* publish/preview/sl-micro_61/html/release-notes
+          mv "$OUTPUT_DIR/html/releasenotes_sle-micro_6.2"/* publish/preview/sl-micro_62/html/release-notes
+          mv "$OUTPUT_DIR/html/releasenotes_sles_16.0"/* publish/preview/sles-16.0/html/release-notes
+          mv "$OUTPUT_DIR/html/releasenotes_sles_16.1"/* publish/preview/sles-16.1/html/release-notes
+          mv "$OUTPUT_DIR/html/releasenotes_sles-sap_16.0"/* publish/preview/slesap-16.0/html/release-notes
+          mv "$OUTPUT_DIR/html/releasenotes_sles-sap_16.1"/* publish/preview/slesap-16.1/html/release-notes
+          echo '<meta http-equiv="refresh" content="0;https://susedoc.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/sles-16.0/html/release-notes/">' > publish/preview/sles-16_SP0/html/release-notes/index.html
+          rm -rf artifact-dir
+          mv publish artifact-dir
+      - name: Publishing preview on susedoc.github.io
+        uses: SUSE/release-notes@gha-publish
+        env:
+          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+        with:
+          artifact-path:  artifact-dir
+          publish-repo: gh:SUSEdoc/release-notes.git
+          repo-reset-after: 0
+          branchless: "false"
+      - name: Comment on PR with preview link
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Find existing comment to avoid duplicate comments
+          comment_id=$(gh pr view ${{ github.event.pull_request.number }} --json comments --jq '.comments[] | select(.body | contains("Release Notes Preview is ready!")) | .id' | head -n1)
+          
+          body="🚀 **Release Notes Preview is ready!**
+
+          You can preview the built release notes here:
+          - [SLES 16.1](https://susedoc.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/sles-16.1/html/release-notes/)
+          - [SLES 16.0](https://susedoc.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/sles-16.0/html/release-notes/)
+          - [SLE HA 16.1](https://susedoc.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/sleha-16.1/html/release-notes/)
+          - [SLE HA 16.0](https://susedoc.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/sleha-16.0/html/release-notes/)
+          - [SLES for SAP 16.1](https://susedoc.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/slesap-16.1/html/release-notes/)
+          - [SLES for SAP 16.0](https://susedoc.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/slesap-16.0/html/release-notes/)
+          - [openSUSE Leap 16.1](https://susedoc.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/leap-16.1/html/release-notes/)
+          - [openSUSE Leap 16.0](https://susedoc.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/leap-16.0/html/release-notes/)
+          - [SLE Micro 6.2](https://susedoc.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/sl-micro_62/html/release-notes/)
+          - [SLE Micro 6.1](https://susedoc.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/sl-micro_61/html/release-notes/)
+          - [SLE Micro 6.0](https://susedoc.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/sl-micro_60/html/release-notes/)
+
+          Directory Index: https://susedoc.github.io/release-notes/refs,pull/${{ github.event.pull_request.number }}/merge/"
+
+          if [ -n "$comment_id" ]; then
+            gh api -X PATCH "repos/${{ github.repository }}/issues/comments/$comment_id" -f body="$body"
+          else
+            gh pr comment ${{ github.event.pull_request.number }} --body "$body"
+          fi

--- a/.github/workflows/asciidoc.yml
+++ b/.github/workflows/asciidoc.yml
@@ -90,7 +90,6 @@ jobs:
     permissions:
       pull-requests: write
       issues: write
-      contents: write
     needs: build
     continue-on-error: true
     steps:
@@ -124,36 +123,18 @@ jobs:
           mv "$OUTPUT_DIR/html/releasenotes_sles_16.1"/* publish/preview/sles-16.1/html/release-notes
           mv "$OUTPUT_DIR/html/releasenotes_sles-sap_16.0"/* publish/preview/slesap-16.0/html/release-notes
           mv "$OUTPUT_DIR/html/releasenotes_sles-sap_16.1"/* publish/preview/slesap-16.1/html/release-notes
-          echo '<meta http-equiv="refresh" content="0;https://suse.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sles-16.0/html/release-notes/">' > publish/preview/sles-16_SP0/html/release-notes/index.html
+          echo '<meta http-equiv="refresh" content="0;https://susedoc.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sles-16.0/html/release-notes/">' > publish/preview/sles-16_SP0/html/release-notes/index.html
           rm -rf artifact-dir
           mv publish artifact-dir
-      - name: Deploy preview to local gh-pages
-        run: |
-          git config --global user.name "SUSE Docs Bot"
-          git config --global user.email "doc-team+docbot@suse.com"
-          
-          git clone --branch gh-pages https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git local-gh-pages || {
-            git clone https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git local-gh-pages
-            cd local-gh-pages
-            git checkout --orphan gh-pages
-            git rm -rf .
-            cd ..
-          }
-          
-          mypubdir="local-gh-pages/refs,pull,${{ github.event.pull_request.number }},merge"
-          rm -rf "$mypubdir"
-          mkdir -p "$mypubdir"
-          cp -r artifact-dir/preview/* "$mypubdir/"
-          touch local-gh-pages/.nojekyll
-          
-          cd local-gh-pages
-          git add -A .
-          if git diff-index --quiet HEAD --; then
-            echo "No changes to deploy."
-          else
-            git commit -m "Deploy preview for PR #${{ github.event.pull_request.number }}"
-            git push origin gh-pages
-          fi
+      - name: Publishing preview on susedoc.github.io
+        uses: SUSE/release-notes@gha-publish
+        env:
+          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+        with:
+          artifact-path:  artifact-dir
+          publish-repo: gh:SUSEdoc/release-notes.git
+          repo-reset-after: 0
+          branchless: "false"
       - name: Comment on PR with preview link
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -164,19 +145,19 @@ jobs:
           body="🚀 **Release Notes Preview is ready!**
 
           You can preview the built release notes here:
-          - [SLES 16.1](https://suse.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sles-16.1/html/release-notes/)
-          - [SLES 16.0](https://suse.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sles-16.0/html/release-notes/)
-          - [SLE HA 16.1](https://suse.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sleha-16.1/html/release-notes/)
-          - [SLE HA 16.0](https://suse.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sleha-16.0/html/release-notes/)
-          - [SLES for SAP 16.1](https://suse.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/slesap-16.1/html/release-notes/)
-          - [SLES for SAP 16.0](https://suse.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/slesap-16.0/html/release-notes/)
-          - [openSUSE Leap 16.1](https://suse.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/leap-16.1/html/release-notes/)
-          - [openSUSE Leap 16.0](https://suse.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/leap-16.0/html/release-notes/)
-          - [SLE Micro 6.2](https://suse.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sl-micro_62/html/release-notes/)
-          - [SLE Micro 6.1](https://suse.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sl-micro_61/html/release-notes/)
-          - [SLE Micro 6.0](https://suse.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sl-micro_60/html/release-notes/)
+          - [SLES 16.1](https://susedoc.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sles-16.1/html/release-notes/)
+          - [SLES 16.0](https://susedoc.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sles-16.0/html/release-notes/)
+          - [SLE HA 16.1](https://susedoc.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sleha-16.1/html/release-notes/)
+          - [SLE HA 16.0](https://susedoc.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sleha-16.0/html/release-notes/)
+          - [SLES for SAP 16.1](https://susedoc.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/slesap-16.1/html/release-notes/)
+          - [SLES for SAP 16.0](https://susedoc.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/slesap-16.0/html/release-notes/)
+          - [openSUSE Leap 16.1](https://susedoc.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/leap-16.1/html/release-notes/)
+          - [openSUSE Leap 16.0](https://susedoc.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/leap-16.0/html/release-notes/)
+          - [SLE Micro 6.2](https://susedoc.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sl-micro_62/html/release-notes/)
+          - [SLE Micro 6.1](https://susedoc.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sl-micro_61/html/release-notes/)
+          - [SLE Micro 6.0](https://susedoc.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sl-micro_60/html/release-notes/)
 
-          Directory Index: https://suse.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/"
+          Directory Index: https://susedoc.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/"
 
           if [ -n "$comment_id" ]; then
             gh api -X PATCH "repos/${{ github.repository }}/issues/comments/$comment_id" -f body="$body"

--- a/.github/workflows/asciidoc.yml
+++ b/.github/workflows/asciidoc.yml
@@ -52,14 +52,14 @@ jobs:
           chmod +x scripts/prepare-publish-hierarchy.sh
           ./scripts/prepare-publish-hierarchy.sh
       - name: Publishing builds on susedoc.github.io
-        uses: SUSE/release-notes@gha-publish
+        uses: openSUSE/doc-ci@lukas-gha-publish-dir
         env:
           DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
         with:
           artifact-path:  artifact-dir
           publish-repo: gh:SUSEdoc/release-notes.git
           repo-reset-after: 35
-          branchless: "true"
+          publish-dir: "root"
 
   preview:
     runs-on: ubuntu-latest
@@ -81,14 +81,14 @@ jobs:
           chmod +x scripts/prepare-publish-hierarchy.sh
           ./scripts/prepare-publish-hierarchy.sh "preview" "https://susedoc.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sles-16.0/html/release-notes/"
       - name: Publishing preview on susedoc.github.io
-        uses: SUSE/release-notes@gha-publish
+        uses: openSUSE/doc-ci@lukas-gha-publish-dir
         env:
           DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
         with:
           artifact-path:  artifact-dir
           publish-repo: gh:SUSEdoc/release-notes.git
           repo-reset-after: 0
-          branchless: "false"
+          publish-dir: "branch"
       - name: Comment on PR with preview link
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/asciidoc.yml
+++ b/.github/workflows/asciidoc.yml
@@ -94,6 +94,7 @@ jobs:
     needs: build
     continue-on-error: true
     steps:
+      - uses: actions/checkout@v4
       - name: Downloading all build artifacts
         id: download-artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/asciidoc.yml
+++ b/.github/workflows/asciidoc.yml
@@ -93,28 +93,5 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Find existing comment to avoid duplicate comments
-          comment_id=$(gh pr view ${{ github.event.pull_request.number }} --json comments --jq '.comments[] | select(.body | contains("Release Notes Preview is ready!")) | .url' | grep -oP '\d+$' | head -n1)
-          
-          body="🚀 **Release Notes Preview is ready!**
-
-          You can preview the built release notes here:
-          - [SLES 16.1](https://susedoc.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sles-16.1/html/release-notes/)
-          - [SLES 16.0](https://susedoc.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sles-16.0/html/release-notes/)
-          - [SLE HA 16.1](https://susedoc.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sleha-16.1/html/release-notes/)
-          - [SLE HA 16.0](https://susedoc.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sleha-16.0/html/release-notes/)
-          - [SLES for SAP 16.1](https://susedoc.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/slesap-16.1/html/release-notes/)
-          - [SLES for SAP 16.0](https://susedoc.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/slesap-16.0/html/release-notes/)
-          - [openSUSE Leap 16.1](https://susedoc.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/leap-16.1/html/release-notes/)
-          - [openSUSE Leap 16.0](https://susedoc.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/leap-16.0/html/release-notes/)
-          - [SLE Micro 6.2](https://susedoc.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sl-micro_62/html/release-notes/)
-          - [SLE Micro 6.1](https://susedoc.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sl-micro_61/html/release-notes/)
-          - [SLE Micro 6.0](https://susedoc.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sl-micro_60/html/release-notes/)
-
-          Directory Index: https://susedoc.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/"
-
-          if [ -n "$comment_id" ]; then
-            gh api -X PATCH "repos/${{ github.repository }}/issues/comments/$comment_id" -f body="$body"
-          else
-            gh pr comment ${{ github.event.pull_request.number }} --body "$body"
-          fi
+          chmod +x scripts/comment-pr-preview.sh
+          ./scripts/comment-pr-preview.sh "${{ github.event.pull_request.number }}" "${{ github.repository }}"

--- a/.github/workflows/asciidoc.yml
+++ b/.github/workflows/asciidoc.yml
@@ -49,31 +49,8 @@ jobs:
           path: artifact-dir
       - name: Create folder hierarchy for susedoc.github.io
         run: |
-          mkdir -p publish/sl-micro{_60,_61,_62}/html/release-notes
-          mkdir -p publish/sles-16.0/html/release-notes
-          mkdir -p publish/sles-16.1/html/release-notes
-          mkdir -p publish/sleha-16.0/html/release-notes
-          mkdir -p publish/sleha-16.1/html/release-notes
-          mkdir -p publish/slesap-16.0/html/release-notes
-          mkdir -p publish/slesap-16.1/html/release-notes
-          mkdir -p publish/sles-16_SP0/html/release-notes
-          mkdir -p publish/leap-16.0/html/release-notes
-          mkdir -p publish/leap-16.1/html/release-notes
-          OUTPUT_DIR=$(find artifact-dir -mindepth 1 -maxdepth 1 -type d)
-          mv "$OUTPUT_DIR/html/releasenotes_leap_16.0"/* publish/leap-16.0/html/release-notes
-          mv "$OUTPUT_DIR/html/releasenotes_leap_16.1"/* publish/leap-16.1/html/release-notes
-          mv "$OUTPUT_DIR/html/releasenotes_sle-ha_16.0"/* publish/sleha-16.0/html/release-notes
-          mv "$OUTPUT_DIR/html/releasenotes_sle-ha_16.1"/* publish/sleha-16.1/html/release-notes
-          mv "$OUTPUT_DIR/html/releasenotes_sle-micro_6.0"/* publish/sl-micro_60/html/release-notes
-          mv "$OUTPUT_DIR/html/releasenotes_sle-micro_6.1"/* publish/sl-micro_61/html/release-notes
-          mv "$OUTPUT_DIR/html/releasenotes_sle-micro_6.2"/* publish/sl-micro_62/html/release-notes
-          mv "$OUTPUT_DIR/html/releasenotes_sles_16.0"/* publish/sles-16.0/html/release-notes
-          mv "$OUTPUT_DIR/html/releasenotes_sles_16.1"/* publish/sles-16.1/html/release-notes
-          mv "$OUTPUT_DIR/html/releasenotes_sles-sap_16.0"/* publish/slesap-16.0/html/release-notes
-          mv "$OUTPUT_DIR/html/releasenotes_sles-sap_16.1"/* publish/slesap-16.1/html/release-notes
-          echo '<meta http-equiv="refresh" content="0;https://susedoc.github.io/release-notes/sles-16.0/html/release-notes/">' > publish/sles-16_SP0/html/release-notes/index.html
-          rm -rf artifact-dir
-          mv publish artifact-dir
+          chmod +x scripts/prepare-publish-hierarchy.sh
+          ./scripts/prepare-publish-hierarchy.sh
       - name: Publishing builds on susedoc.github.io
         uses: SUSE/release-notes@gha-publish
         env:
@@ -101,31 +78,8 @@ jobs:
           path: artifact-dir
       - name: Create folder hierarchy for preview
         run: |
-          mkdir -p publish/preview/sl-micro{_60,_61,_62}/html/release-notes
-          mkdir -p publish/preview/sles-16.0/html/release-notes
-          mkdir -p publish/preview/sles-16.1/html/release-notes
-          mkdir -p publish/preview/sleha-16.0/html/release-notes
-          mkdir -p publish/preview/sleha-16.1/html/release-notes
-          mkdir -p publish/preview/slesap-16.0/html/release-notes
-          mkdir -p publish/preview/slesap-16.1/html/release-notes
-          mkdir -p publish/preview/sles-16_SP0/html/release-notes
-          mkdir -p publish/preview/leap-16.0/html/release-notes
-          mkdir -p publish/preview/leap-16.1/html/release-notes
-          OUTPUT_DIR=$(find artifact-dir -mindepth 1 -maxdepth 1 -type d)
-          mv "$OUTPUT_DIR/html/releasenotes_leap_16.0"/* publish/preview/leap-16.0/html/release-notes
-          mv "$OUTPUT_DIR/html/releasenotes_leap_16.1"/* publish/preview/leap-16.1/html/release-notes
-          mv "$OUTPUT_DIR/html/releasenotes_sle-ha_16.0"/* publish/preview/sleha-16.0/html/release-notes
-          mv "$OUTPUT_DIR/html/releasenotes_sle-ha_16.1"/* publish/preview/sleha-16.1/html/release-notes
-          mv "$OUTPUT_DIR/html/releasenotes_sle-micro_6.0"/* publish/preview/sl-micro_60/html/release-notes
-          mv "$OUTPUT_DIR/html/releasenotes_sle-micro_6.1"/* publish/preview/sl-micro_61/html/release-notes
-          mv "$OUTPUT_DIR/html/releasenotes_sle-micro_6.2"/* publish/preview/sl-micro_62/html/release-notes
-          mv "$OUTPUT_DIR/html/releasenotes_sles_16.0"/* publish/preview/sles-16.0/html/release-notes
-          mv "$OUTPUT_DIR/html/releasenotes_sles_16.1"/* publish/preview/sles-16.1/html/release-notes
-          mv "$OUTPUT_DIR/html/releasenotes_sles-sap_16.0"/* publish/preview/slesap-16.0/html/release-notes
-          mv "$OUTPUT_DIR/html/releasenotes_sles-sap_16.1"/* publish/preview/slesap-16.1/html/release-notes
-          echo '<meta http-equiv="refresh" content="0;https://susedoc.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sles-16.0/html/release-notes/">' > publish/preview/sles-16_SP0/html/release-notes/index.html
-          rm -rf artifact-dir
-          mv publish artifact-dir
+          chmod +x scripts/prepare-publish-hierarchy.sh
+          ./scripts/prepare-publish-hierarchy.sh "preview" "https://susedoc.github.io/release-notes/refs,pull,${{ github.event.pull_request.number }},merge/sles-16.0/html/release-notes/"
       - name: Publishing preview on susedoc.github.io
         uses: SUSE/release-notes@gha-publish
         env:

--- a/scripts/comment-pr-preview.sh
+++ b/scripts/comment-pr-preview.sh
@@ -12,24 +12,69 @@ if [ -z "$PR_NUMBER" ] || [ -z "$REPO" ]; then
   exit 1
 fi
 
+pretty_name() {
+  case $1 in
+    sles-16.0) echo "SLES 16.0" ;;
+    sles-16.1) echo "SLES 16.1" ;;
+    sles-16.2) echo "SLES 16.2" ;;
+    sles-16_SP0) echo "SLES 16 SP0 (Redirect)" ;;
+    sleha-16.0) echo "SLE HA 16.0" ;;
+    sleha-16.1) echo "SLE HA 16.1" ;;
+    slesap-16.0) echo "SLES for SAP 16.0" ;;
+    slesap-16.1) echo "SLES for SAP 16.1" ;;
+    leap-16.0) echo "openSUSE Leap 16.0" ;;
+    leap-16.1) echo "openSUSE Leap 16.1" ;;
+    sl-micro_60) echo "SLE Micro 6.0" ;;
+    sl-micro_61) echo "SLE Micro 6.1" ;;
+    sl-micro_62) echo "SLE Micro 6.2" ;;
+    sl-micro_63) echo "SLE Micro 6.3" ;;
+    *)
+      # Fallback: capitalize and replace hyphen/underscore
+      echo "$1" | tr '_-' '  ' | awk '{for(i=1;i<=NF;i++)sub(/./,toupper(substr($i,1,1)),$i)}1'
+      ;;
+  esac
+}
+
+# Find all DC-* files for active products and build links dynamically
+links=""
+for dc_file in DC-releasenotes_*; do
+  [ -f "$dc_file" ] || continue
+  
+  # Extract the suffix after DC-releasenotes_
+  suffix="${dc_file#DC-releasenotes_}"
+  
+  # Map the suffix to the published directory name
+  case "$suffix" in
+    sles_16.0) p="sles-16.0" ;;
+    sles_16.1) p="sles-16.1" ;;
+    sles_16.2) p="sles-16.2" ;;
+    sle-ha_16.0) p="sleha-16.0" ;;
+    sle-ha_16.1) p="sleha-16.1" ;;
+    sles-sap_16.0) p="slesap-16.0" ;;
+    sles-sap_16.1) p="slesap-16.1" ;;
+    leap_16.0) p="leap-16.0" ;;
+    leap_16.1) p="leap-16.1" ;;
+    sle-micro_6.0) p="sl-micro_60" ;;
+    sle-micro_6.1) p="sl-micro_61" ;;
+    sle-micro_6.2) p="sl-micro_62" ;;
+    sle-micro_6.3) p="sl-micro_63" ;;
+    *) p="" ;; # Ignore legacy/unmapped DC files
+  esac
+  
+  # Only link if the mapped directory actually exists in the built preview folder
+  if [ -n "$p" ] && [ -d "artifact-dir/preview/$p" ]; then
+    title=$(pretty_name "$p")
+    links="${links}- [$title](https://susedoc.github.io/release-notes/refs,pull,${PR_NUMBER},merge/${p}/html/release-notes/)\n"
+  fi
+done
+
 # Find existing comment to avoid duplicate comments
 comment_id=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json comments --jq '.comments[] | select(.body | contains("Release Notes Preview is ready!")) | .url' | grep -oP '\d+$' | head -n1)
 
-body="🚀 **Preview is ready!**
+body="🚀 **Release Notes Preview is ready!**
 
 You can preview the built release notes here:
-- [SLES 16.1](https://susedoc.github.io/release-notes/refs,pull,${PR_NUMBER},merge/sles-16.1/html/release-notes/)
-- [SLES 16.0](https://susedoc.github.io/release-notes/refs,pull,${PR_NUMBER},merge/sles-16.0/html/release-notes/)
-- [SLE HA 16.1](https://susedoc.github.io/release-notes/refs,pull,${PR_NUMBER},merge/sleha-16.1/html/release-notes/)
-- [SLE HA 16.0](https://susedoc.github.io/release-notes/refs,pull,${PR_NUMBER},merge/sleha-16.0/html/release-notes/)
-- [SLES for SAP 16.1](https://susedoc.github.io/release-notes/refs,pull,${PR_NUMBER},merge/slesap-16.1/html/release-notes/)
-- [SLES for SAP 16.0](https://susedoc.github.io/release-notes/refs,pull,${PR_NUMBER},merge/slesap-16.0/html/release-notes/)
-- [openSUSE Leap 16.1](https://susedoc.github.io/release-notes/refs,pull,${PR_NUMBER},merge/leap-16.1/html/release-notes/)
-- [openSUSE Leap 16.0](https://susedoc.github.io/release-notes/refs,pull,${PR_NUMBER},merge/leap-16.0/html/release-notes/)
-- [SLE Micro 6.2](https://susedoc.github.io/release-notes/refs,pull,${PR_NUMBER},merge/sl-micro_62/html/release-notes/)
-- [SLE Micro 6.1](https://susedoc.github.io/release-notes/refs,pull,${PR_NUMBER},merge/sl-micro_61/html/release-notes/)
-- [SLE Micro 6.0](https://susedoc.github.io/release-notes/refs,pull,${PR_NUMBER},merge/sl-micro_60/html/release-notes/)
-
+$(echo -e "$links")
 Directory Index: https://susedoc.github.io/release-notes/refs,pull,${PR_NUMBER},merge/"
 
 if [ -n "$comment_id" ]; then

--- a/scripts/comment-pr-preview.sh
+++ b/scripts/comment-pr-preview.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# scripts/comment-pr-preview.sh
+# Comments on the pull request with active preview URLs
+
+set -e
+
+PR_NUMBER="${1}"
+REPO="${2}"
+
+if [ -z "$PR_NUMBER" ] || [ -z "$REPO" ]; then
+  echo "Error: PR number and REPO are required. Usage: $0 <PR_NUMBER> <REPO>"
+  exit 1
+fi
+
+# Find existing comment to avoid duplicate comments
+comment_id=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json comments --jq '.comments[] | select(.body | contains("Release Notes Preview is ready!")) | .url' | grep -oP '\d+$' | head -n1)
+
+body="🚀 **Release Notes Preview is ready!**
+
+You can preview the built release notes here:
+- [SLES 16.1](https://susedoc.github.io/release-notes/refs,pull,${PR_NUMBER},merge/sles-16.1/html/release-notes/)
+- [SLES 16.0](https://susedoc.github.io/release-notes/refs,pull,${PR_NUMBER},merge/sles-16.0/html/release-notes/)
+- [SLE HA 16.1](https://susedoc.github.io/release-notes/refs,pull,${PR_NUMBER},merge/sleha-16.1/html/release-notes/)
+- [SLE HA 16.0](https://susedoc.github.io/release-notes/refs,pull,${PR_NUMBER},merge/sleha-16.0/html/release-notes/)
+- [SLES for SAP 16.1](https://susedoc.github.io/release-notes/refs,pull,${PR_NUMBER},merge/slesap-16.1/html/release-notes/)
+- [SLES for SAP 16.0](https://susedoc.github.io/release-notes/refs,pull,${PR_NUMBER},merge/slesap-16.0/html/release-notes/)
+- [openSUSE Leap 16.1](https://susedoc.github.io/release-notes/refs,pull,${PR_NUMBER},merge/leap-16.1/html/release-notes/)
+- [openSUSE Leap 16.0](https://susedoc.github.io/release-notes/refs,pull,${PR_NUMBER},merge/leap-16.0/html/release-notes/)
+- [SLE Micro 6.2](https://susedoc.github.io/release-notes/refs,pull,${PR_NUMBER},merge/sl-micro_62/html/release-notes/)
+- [SLE Micro 6.1](https://susedoc.github.io/release-notes/refs,pull,${PR_NUMBER},merge/sl-micro_61/html/release-notes/)
+- [SLE Micro 6.0](https://susedoc.github.io/release-notes/refs,pull,${PR_NUMBER},merge/sl-micro_60/html/release-notes/)
+
+Directory Index: https://susedoc.github.io/release-notes/refs,pull,${PR_NUMBER},merge/"
+
+if [ -n "$comment_id" ]; then
+  gh api -X PATCH "repos/${REPO}/issues/comments/$comment_id" -f body="$body"
+else
+  gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$body"
+fi

--- a/scripts/comment-pr-preview.sh
+++ b/scripts/comment-pr-preview.sh
@@ -15,7 +15,7 @@ fi
 # Find existing comment to avoid duplicate comments
 comment_id=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json comments --jq '.comments[] | select(.body | contains("Release Notes Preview is ready!")) | .url' | grep -oP '\d+$' | head -n1)
 
-body="🚀 **Release Notes Preview is ready!**
+body="🚀 **Preview is ready!**
 
 You can preview the built release notes here:
 - [SLES 16.1](https://susedoc.github.io/release-notes/refs,pull,${PR_NUMBER},merge/sles-16.1/html/release-notes/)

--- a/scripts/prepare-publish-hierarchy.sh
+++ b/scripts/prepare-publish-hierarchy.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# scripts/prepare-publish-hierarchy.sh
+# Prepares the folder hierarchy for susedoc.github.io (both production and PR previews)
+
+set -e
+
+SUBFOLDER="${1:-}" # e.g. "preview" or empty
+REDIRECT_URL="${2:-https://susedoc.github.io/release-notes/sles-16.0/html/release-notes/}"
+
+# If SUBFOLDER is not empty, add a trailing slash for paths
+if [ -n "$SUBFOLDER" ]; then
+  DEST_PREFIX="publish/$SUBFOLDER"
+else
+  DEST_PREFIX="publish"
+fi
+
+mkdir -p "$DEST_PREFIX"/sl-micro{_60,_61,_62}/html/release-notes
+mkdir -p "$DEST_PREFIX"/sles-16.0/html/release-notes
+mkdir -p "$DEST_PREFIX"/sles-16.1/html/release-notes
+mkdir -p "$DEST_PREFIX"/sleha-16.0/html/release-notes
+mkdir -p "$DEST_PREFIX"/sleha-16.1/html/release-notes
+mkdir -p "$DEST_PREFIX"/slesap-16.0/html/release-notes
+mkdir -p "$DEST_PREFIX"/slesap-16.1/html/release-notes
+mkdir -p "$DEST_PREFIX"/sles-16_SP0/html/release-notes
+mkdir -p "$DEST_PREFIX"/leap-16.0/html/release-notes
+mkdir -p "$DEST_PREFIX"/leap-16.1/html/release-notes
+
+OUTPUT_DIR=$(find artifact-dir -mindepth 1 -maxdepth 1 -type d)
+
+mv "$OUTPUT_DIR/html/releasenotes_leap_16.0"/* "$DEST_PREFIX"/leap-16.0/html/release-notes
+mv "$OUTPUT_DIR/html/releasenotes_leap_16.1"/* "$DEST_PREFIX"/leap-16.1/html/release-notes
+mv "$OUTPUT_DIR/html/releasenotes_sle-ha_16.0"/* "$DEST_PREFIX"/sleha-16.0/html/release-notes
+mv "$OUTPUT_DIR/html/releasenotes_sle-ha_16.1"/* "$DEST_PREFIX"/sleha-16.1/html/release-notes
+mv "$OUTPUT_DIR/html/releasenotes_sle-micro_6.0"/* "$DEST_PREFIX"/sl-micro_60/html/release-notes
+mv "$OUTPUT_DIR/html/releasenotes_sle-micro_6.1"/* "$DEST_PREFIX"/sl-micro_61/html/release-notes
+mv "$OUTPUT_DIR/html/releasenotes_sle-micro_6.2"/* "$DEST_PREFIX"/sl-micro_62/html/release-notes
+mv "$OUTPUT_DIR/html/releasenotes_sles_16.0"/* "$DEST_PREFIX"/sles-16.0/html/release-notes
+mv "$OUTPUT_DIR/html/releasenotes_sles_16.1"/* "$DEST_PREFIX"/sles-16.1/html/release-notes
+mv "$OUTPUT_DIR/html/releasenotes_sles-sap_16.0"/* "$DEST_PREFIX"/slesap-16.0/html/release-notes
+mv "$OUTPUT_DIR/html/releasenotes_sles-sap_16.1"/* "$DEST_PREFIX"/slesap-16.1/html/release-notes
+
+echo "<meta http-equiv=\"refresh\" content=\"0;${REDIRECT_URL}\">" > "$DEST_PREFIX"/sles-16_SP0/html/release-notes/index.html
+
+rm -rf artifact-dir
+mv publish artifact-dir


### PR DESCRIPTION
Closes #11. This change runs the build job on all pull requests, uploading the built release notes as build artifacts. Reviewers can download the artifact to preview the built HTML notes.