### PR TITLE
SLES 16.0: Document discontinued packages (jsc#PED-11051)

### DIFF
--- a/adoc/sles/release-notes-sles-160-docinfo.xml
+++ b/adoc/sles/release-notes-sles-160-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xml:id="revhistory" xmlns:xlink="http://www.w3.org/1999/xlink">
     <revision>
+     <date>2026-07-20</date>
+     <revdescription>
+      <itemizedlist>
+       <listitem>
+        <para>Documented discontinued legacy packages from SLE 15 (<link xlink:href="index.html#removed">jsc#PED-11051</link>)</para>
+       </listitem>
+      </itemizedlist>
+     </revdescription>
+    </revision>
+    <revision>
      <date>2026-07-17</date>
      <revdescription>
       <itemizedlist>

--- a/adoc/sles/release-notes-sles-160.adoc
+++ b/adoc/sles/release-notes-sles-160.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version160.adoc[]
 
 = SUSE Linux Enterprise Server Release Notes
-:revdate: 2026-07-17
+:revdate: 2026-07-20
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/sles/version160.adoc
+++ b/adoc/sles/version160.adoc
@@ -1206,6 +1206,38 @@ This section lists features and packages that were removed from {productname} or
 
 The following features and packages have been removed in this release.
 
+// jsc#PED-11051
+* Support for several legacy packages previously available in {slesa} 15 has been discontinued.
+These packages have been removed from {productname} {this-version}.
+The removed packages include:
+** `bluez-firmware`, `atmel-firmware`, and `adaptec-firmware`
+** `CIM` infrastructure (including `openwsman` and `sblim-*`)
+** `cpuset`
+** `fbiterm`
+** `fwupdate` and `dbxtools` (functionality now part of `fwupd`)
+** `gamin`
+** `gconf2`
+** `gnustep-base`
+** `gtk-vnc2`
+** `haveged`
+** `hfsutils`
+** `iceauth`
+** `icmpinfo`
+** `ipsec-tools`
+** `ISC dhcp` (replaced by `kea`)
+** `iw`
+** `librdkafka`
+** `memkind`
+** `mpitests`
+** `netcontrol`
+** `openldap`
+** `pidentd`
+** `powerman`
+** `quagga` (superseded by `frr`)
+** `redis7`
+** `salt` and associated package components (including `python3-salt`, `salt-api`, `salt-master`, and `salt-minion`)
+** `vacation`
+
 // jsc#PED-11281
 * The `hplip` package has been removed.
 The upstream project is no longer active (jsc#PED-11281).


### PR DESCRIPTION
This pull request documents the discontinued/removed packages from SLE 15 to SLE 16.0 as requested in Jira issue PED-11051 (linked to Epic PED-10219).