### PR TITLE
SLES 16.0, SLES 16.1: Agama SSH public key support (jsc#PED-15435)

### DIFF
--- a/adoc/shared.adoc
+++ b/adoc/shared.adoc
@@ -288,3 +288,11 @@ Load profiles into the installer service using `agama config load < profile.json
 end::jscped-15454[]
 
 
+
+tag::jscped-15435[]
+[#jsc-PED-15435]
+= SSH public key support for all accounts created during installation
+
+The Agama installer supports SSH public key authentication for all accounts created during installation, including the first non-root account.
+This eliminates the need for temporary passwords and improves post-installation security.
+end::jscped-15435[]

--- a/adoc/sles/release-notes-sles-160-docinfo.xml
+++ b/adoc/sles/release-notes-sles-160-docinfo.xml
@@ -20,6 +20,9 @@
        <listitem>
         <para>Added section <link xlink:href="index.html#jsc-PED-15454">Automated generation and validation of Agama profiles</link> (jsc#PED-15454)</para>
        </listitem>
+       <listitem>
+        <para>Added section <link xlink:href="index.html#jsc-PED-15435">SSH public key support for all accounts created during installation</link> (jsc#PED-15435)</para>
+       </listitem>
       </itemizedlist>
      </revdescription>
     </revision>

--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -17,6 +17,9 @@
       <listitem>
        <para>Added section <link xlink:href="index.html#jsc-PED-15454">Automated generation and validation of Agama profiles</link> (jsc#PED-15454)</para>
       </listitem>
+      <listitem>
+       <para>Added section <link xlink:href="index.html#jsc-PED-15435">SSH public key support for all accounts created during installation</link> (jsc#PED-15435)</para>
+      </listitem>
      </itemizedlist>
     </revdescription>
   </revision>

--- a/adoc/sles/version160.adoc
+++ b/adoc/sles/version160.adoc
@@ -180,6 +180,9 @@ See <<jsc-PED-6311>>.
 // jsc#PED-11656
 * We now provide a unified image that can be used to install either {slesa} or {slessapa}
 
+// jsc#PED-15435
+include::../shared.adoc[tags=jscped-15435,leveloffset=+2]
+
 // jsc#PED-15454
 include::../shared.adoc[tags=jscped-15454,leveloffset=+2]
 

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -157,6 +157,9 @@ See <<jsc-PED-16106>>.
 // jsc#PED-12658
 * `rasdaemon` has been updated to version 0.8.4. This version supports machine checks related to CXL memory. Since Intel® Optane™ Memory products have reached End of Life (EOL), {productname} {this-version} does not support them either.
 
+// jsc#PED-15435
+include::../shared.adoc[tags=jscped-15435,leveloffset=+2]
+
 // jsc#PED-15454
 include::../shared.adoc[tags=jscped-15454,leveloffset=+2]
 


### PR DESCRIPTION
This Pull Request adds the release notes for the new Agama installer capability supporting SSH public key configuration for all accounts created during installation (jsc#PED-15435) for SLES 16.0 and SLES 16.1. It also propagates the related root login passwordless SSH restriction warning to SLES 16.1 (bsc#1240889) and updates the respective changelogs.