### PR TITLE
SLES 16.1: Correct virtualization release notes structure and formatting

### DIFF
--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -11,6 +11,28 @@
 <date>{revdate}</date>
 <revhistory xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-07-21</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Added note about disabled iSCSI boot support in OVMF images (bsc#1245454)</para>
+      </listitem>
+      <listitem>
+       <para>Documented QEMU version 11.0.0 update (jsc#PED-14599)</para>
+      </listitem>
+      <listitem>
+       <para>Documented libvirt version 12.3.0 update and modular daemons (jsc#PED-14623)</para>
+      </listitem>
+      <listitem>
+       <para>Added section about Intel TDX Confidential Computing (jsc#PED-15646)</para>
+      </listitem>
+      <listitem>
+       <para>Documented updates to other virtualization utilities including virt-bridge-setup (jsc#PED-14624)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-07-20</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -15,19 +15,19 @@
     <revdescription>
      <itemizedlist>
       <listitem>
-       <para>Added note about disabled iSCSI boot support in OVMF images (bsc#1245454)</para>
+       <para>Added note about disabled <link xlink:href="index.html#virtualization">iSCSI boot support in OVMF images</link> (bsc#1245454)</para>
       </listitem>
       <listitem>
-       <para>Documented QEMU version 11.0.0 update (jsc#PED-14599)</para>
+       <para>Documented <link xlink:href="index.html#jsc-PED-14599">QEMU version 11.0.0 update</link> (jsc#PED-14599)</para>
       </listitem>
       <listitem>
-       <para>Documented libvirt version 12.3.0 update and modular daemons (jsc#PED-14623)</para>
+       <para>Documented <link xlink:href="index.html#jsc-PED-14623">libvirt version 12.3.0 update and modular daemons</link> (jsc#PED-14623)</para>
       </listitem>
       <listitem>
-       <para>Added section about Intel TDX Confidential Computing (jsc#PED-15646)</para>
+       <para>Added section about <link xlink:href="index.html#jsc-PED-15646">Intel TDX Confidential Computing</link> and its <link xlink:href="index.html#jsc-PED-15646-tech-preview">remote attestation technology preview</link> (jsc#PED-15646)</para>
       </listitem>
       <listitem>
-       <para>Documented updates to other virtualization utilities including virt-bridge-setup (jsc#PED-14624)</para>
+       <para>Documented updates to <link xlink:href="index.html#jsc-PED-14624">other virtualization utilities</link> including virt-bridge-setup (jsc#PED-14624)</para>
       </listitem>
      </itemizedlist>
     </revdescription>

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -53,7 +53,7 @@ sections in this document:
 
 // * <<kernel>>
 // * <<storage>>
-// * <<virtualization>>
+* <<virtualization>>
 * <<removed-deprecated>>
 
 [#intro-support-external]

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -395,7 +395,7 @@ include::../shared.adoc[tag=jscped-15968,leveloffset=+2]
 //    KVM, libvirt, ...
 
 // bsc#1245454
-* iSCSI boot support is disabled in OVMF images (bsc#1245454).
+* iSCSI boot support is disabled in OVMF images.
 
 
 [#jsc-PED-14599]

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -117,7 +117,6 @@ The following limitations apply to this technology preview:
 
 Full support is planned for a future release.
 
-// jsc#PED-15646
 [#jsc-PED-15646-tech-preview]
 === Intel TDX Remote Attestation (technology preview)
 

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -117,6 +117,18 @@ The following limitations apply to this technology preview:
 
 Full support is planned for a future release.
 
+// jsc#PED-15646
+[#jsc-PED-15646-tech-preview]
+=== Intel TDX Remote Attestation (technology preview)
+
+As a technology preview, remote attestation is available via the following packages in {productname} {this-version}:
+
+* `confidential-computing.sgx`
+* `confidential-computing.tee.dcap.pccs`
+* `guest-components`
+* `suse-libsgx-prebuilt-signed`
+* `trustee`
+
 // jsc#PED-13609
 // jsc#PED-15556
 [#jsc-PED-15556]
@@ -438,14 +450,7 @@ The following AMD Secure Encrypted Virtualization (SEV) tools have been updated:
 ==== Intel TDX Confidential Computing
 
 Intel TDX is supported in {productname} {this-version}.
-
-As a technology preview, remote attestation is available via the following packages:
-
-* `confidential-computing.sgx`
-* `confidential-computing.tee.dcap.pccs`
-* `guest-components`
-* `suse-libsgx-prebuilt-signed`
-* `trustee`
+For details on Intel TDX remote attestation, see <<jsc-PED-15646-tech-preview>>.
 
 
 [#jsc-PED-14624]

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -402,15 +402,15 @@ include::../shared.adoc[tag=jscped-15968,leveloffset=+2]
 === QEMU
 
 QEMU has been updated to version 11.0.0.
-For a full list of changes, see https://wiki.qemu.org/ChangeLog/11.0.
-For details on removed or deprecated features, see https://qemu-project.gitlab.io/qemu/about/removed-features.html and https://qemu-project.gitlab.io/qemu/about/deprecated.html.
+For changes, see https://wiki.qemu.org/ChangeLog/11.0.
+For removed or deprecated features, see https://qemu-project.gitlab.io/qemu/about/removed-features.html and https://qemu-project.gitlab.io/qemu/about/deprecated.html.
 
 
 [#jsc-PED-14623]
 === libvirt
 
 `libvirt` has been updated to version 12.3.0, introducing modular daemons.
-For a list of other improvements and bug fixes, see https://libvirt.org/news.html#v12-3-0-2026-05-02.
+For details, see https://libvirt.org/news.html#v12-3-0-2026-05-02.
 
 
 [#virtualization-vmware]
@@ -419,7 +419,7 @@ For a list of other improvements and bug fixes, see https://libvirt.org/news.htm
 ==== open-vm-tools
 
 `open-vm-tools` has been updated to version 13.1.0.
-For details on bug fixes and security updates, see the release notes at https://github.com/vmware/open-vm-tools/blob/stable-13.1.0/ReleaseNotes.md.
+For details, see https://github.com/vmware/open-vm-tools/blob/stable-13.1.0/ReleaseNotes.md.
 
 
 [#virtualization-confidential-computing]
@@ -430,7 +430,7 @@ For details on bug fixes and security updates, see the release notes at https://
 The following AMD Secure Encrypted Virtualization (SEV) tools have been updated:
 
 * `sevctl` has been updated to version 0.6.2.
-* `snpguest` has been updated to version 0.10.0. For a list of changes, see https://github.com/virtee/snpguest/compare/v0.9.1...v0.10.0.
+* `snpguest` has been updated to version 0.10.0. For changes, see https://github.com/virtee/snpguest/compare/v0.9.1...v0.10.0.
 * `snphost` has been updated to version 0.7.0.
 
 

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -395,54 +395,46 @@ include::../shared.adoc[tag=jscped-15968,leveloffset=+2]
 //    KVM, libvirt, ...
 
 // bsc#1245454
-* iSCSI boot support is disabled in OVMF images.
+* iSCSI boot support is disabled in OVMF images (bsc#1245454).
 
 
-[#virtualization-qemu]
-//jsc-PED-14599
+[#jsc-PED-14599]
 === QEMU
 
 QEMU has been updated to version 11.0.0.
-The full list of changes is available at https://wiki.qemu.org/ChangeLog/11.0.
+For a full list of changes, see https://wiki.qemu.org/ChangeLog/11.0.
+For details on removed or deprecated features, see https://qemu-project.gitlab.io/qemu/about/removed-features.html and https://qemu-project.gitlab.io/qemu/about/deprecated.html.
 
-Highlights include:
-* Removed features: https://qemu-project.gitlab.io/qemu/about/removed-features.html
-* Deprecated features: https://qemu-project.gitlab.io/qemu/about/deprecated.html
 
-[#virtualization-libvirt]
-// jsc-PED-14623
+[#jsc-PED-14623]
 === libvirt
 
-`libvirt` has been updated to version 12.3.0.
-This release includes incremental improvements and bug fixes (see https://libvirt.org/news.html#v12-3-0-2026-05-02).
-`libvirt` now provides modular daemons.
+`libvirt` has been updated to version 12.3.0, introducing modular daemons.
+For a list of other improvements and bug fixes, see https://libvirt.org/news.html#v12-3-0-2026-05-02.
+
 
 [#virtualization-vmware]
 === VMware
 
 ==== open-vm-tools
 
-`open-vm-tools` has been updated to version 13.1.0, addressing critical problems and bugs.
-See the release notes at https://github.com/vmware/open-vm-tools/blob/stable-13.1.0/ReleaseNotes.md.
+`open-vm-tools` has been updated to version 13.1.0.
+For details on bug fixes and security updates, see the release notes at https://github.com/vmware/open-vm-tools/blob/stable-13.1.0/ReleaseNotes.md.
+
 
 [#virtualization-confidential-computing]
 === Confidential Computing
 
-==== `sevctl`
+==== AMD SEV packages update
 
-The `sevctl` package has been updated to version 0.6.2.
+The following AMD Secure Encrypted Virtualization (SEV) tools have been updated:
 
-==== `snpguest`
+* `sevctl` has been updated to version 0.6.2.
+* `snpguest` has been updated to version 0.10.0. For a list of changes, see https://github.com/virtee/snpguest/compare/v0.9.1...v0.10.0.
+* `snphost` has been updated to version 0.7.0.
 
-The `snpguest` package has been updated to version 0.10.0.
-The full list of changes is available at https://github.com/virtee/snpguest/compare/v0.9.1...v0.10.0.
 
-==== `snphost`
-
-The `snphost` package has been updated to version 0.7.0.
-
-//jsc#PED-15646
-[#intel-tdx-confidential-computing]
+[#jsc-PED-15646]
 ==== Intel TDX Confidential Computing
 
 Intel TDX is supported in {productname} {this-version}.
@@ -455,53 +447,30 @@ As a technology preview, remote attestation is available via the following packa
 * `suse-libsgx-prebuilt-signed`
 * `trustee`
 
-[#virtualization-other]
-//jsc-PED-14624
+
+[#jsc-PED-14624]
 === Other tools
 
-==== numatop
+The following virtualization utilities have been updated:
 
-`numatop` is available in version 2.5, adding support for Intel GNR and SRF platforms.
+* `numatop` has been updated to version 2.5, adding support for Intel GNR and SRF platforms.
+* `numactl` has been updated to version 2.0.19 (see https://github.com/numactl/numactl/releases/tag/v2.0.19).
+* `libguestfs` has been updated to version 1.58.1.
+* `virt-v2v` has been updated to version 2.10.0, introducing the `--parallel=N` parameter for parallel disk copies (see https://github.com/libguestfs/virt-v2v/tree/v2.10.0).
+* `virtiofsd` has been updated to version 1.12.0.
+* `virt-manager` has been updated to version 5.1.0. Direct XML editing via `virsh` and remote viewing via VNC are recommended (see https://github.com/virt-manager/virt-manager/releases/tag/v5.1.0).
 
-==== numactl
 
-`numactl` is shipped in version 2.0.19.
-The full changelog is available at https://github.com/numactl/numactl/releases/tag/v2.0.19.
+==== `virt-bridge-setup`
 
-==== libguestfs
-
-`libguestfs` has been updated to version 1.58.1.
-
-==== virt-v2v
-
-`virt-v2v` has been updated to version 2.10.0.
-The code changes are available at https://github.com/libguestfs/virt-v2v/tree/v2.10.0.
-
-- Implement `--parallel=N` for parallel disk copies.
-- Update translations.
-- Various fixes.
-
-==== `virtiofsd`
-
-The `virtiofsd` package has been updated to version 1.12.0.
-
-==== `virt-manager`
-
-`virt-manager` is now shipped in version 5.1.0.
-Using VNC for remote viewing and editing XML configuration directly with the `virsh` command is recommended.
-The full list of changes is available at https://github.com/virt-manager/virt-manager/releases/tag/v5.1.0.
-
-==== virt-bridge-setup
-
-`virt-bridge-setup` is a script designed to simplify network bridge creation on a specified interface using `nmcli`.
-It was developed as a replacement for the automatic `yast2 virtualization` bridge creation and is particularly useful for setting up virtualization environments.
+`virt-bridge-setup` is a new script designed to simplify network bridge creation on a specified interface using `nmcli`.
+It replaces the automatic bridge creation previously managed by `yast2 virtualization`.
 
 Important considerations:
 
 * It supports IPv4 only.
-* This is a simple script not intended for complex network scenarios (VLAN, bonding, etc.).
-* Manual bridge setup is recommended for intricate configurations.
-* The script should be run locally (not remotely) immediately after installation and before any custom network configurations.
+* It is not intended for complex network configurations (such as VLANs or bonding); manual bridge setup is recommended for these scenarios.
+* The script must be run locally (not over a remote connection) immediately after installation and before applying any custom network configurations.
 
 
 

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -402,7 +402,8 @@ include::../shared.adoc[tag=jscped-15968,leveloffset=+2]
 //jsc-PED-14599
 === QEMU
 
-QEMU has been updated to version 11.0.0, full list of changes are available at https://wiki.qemu.org/ChangeLog/11.0
+QEMU has been updated to version 11.0.0.
+The full list of changes is available at https://wiki.qemu.org/ChangeLog/11.0.
 
 Highlights include:
 * Removed features: https://qemu-project.gitlab.io/qemu/about/removed-features.html
@@ -412,29 +413,31 @@ Highlights include:
 // jsc-PED-14623
 === libvirt
 
-`libvirt` has been updated to version 12.3.0, this include many incremental improvements and bug fixes, see https://libvirt.org/news.html#v12-3-0-2026-05-02.
-
-`libvirt` provides now a modular daemons.
+`libvirt` has been updated to version 12.3.0.
+This release includes incremental improvements and bug fixes (see https://libvirt.org/news.html#v12-3-0-2026-05-02).
+`libvirt` now provides modular daemons.
 
 [#virtualization-vmware]
 === VMware
 
-===== open-vm-tools
+==== open-vm-tools
 
-`open-vm-tools` has been updated to version 13.1.0 that addresses a few critical problems and bug fixes. See https://github.com/vmware/open-vm-tools/blob/stable-13.1.0/ReleaseNotes.md.
+`open-vm-tools` has been updated to version 13.1.0, addressing critical problems and bugs.
+See the release notes at https://github.com/vmware/open-vm-tools/blob/stable-13.1.0/ReleaseNotes.md.
 
-==== Confidential Computing
+[#virtualization-confidential-computing]
+=== Confidential Computing
 
-===== `sevctl`
+==== `sevctl`
 
 The `sevctl` package has been updated to version 0.6.2.
 
-===== `snpguest`
+==== `snpguest`
 
 The `snpguest` package has been updated to version 0.10.0.
-Full list of changes is available at: https://github.com/virtee/snpguest/compare/v0.9.1...v0.10.0
+The full list of changes is available at https://github.com/virtee/snpguest/compare/v0.9.1...v0.10.0.
 
-===== `snphost`
+==== `snphost`
 
 The `snphost` package has been updated to version 0.7.0.
 
@@ -444,7 +447,7 @@ The `snphost` package has been updated to version 0.7.0.
 
 Intel TDX is supported in {productname} {this-version}.
 
-As technology preview, remote attestation is available via the following packages:
+As a technology preview, remote attestation is available via the following packages:
 
 * `confidential-computing.sgx`
 * `confidential-computing.tee.dcap.pccs`
@@ -456,46 +459,48 @@ As technology preview, remote attestation is available via the following package
 //jsc-PED-14624
 === Other tools
 
-===== numatop
+==== numatop
 
 `numatop` is available in version 2.5, adding support for Intel GNR and SRF platforms.
 
-===== numactl
+==== numactl
 
 `numactl` is shipped in version 2.0.19.
-Full changes at: https://github.com/numactl/numactl/releases/tag/v2.0.19
+The full changelog is available at https://github.com/numactl/numactl/releases/tag/v2.0.19.
 
-===== libguestfs
+==== libguestfs
 
 `libguestfs` has been updated to version 1.58.1.
 
-===== virt-v2v
+==== virt-v2v
 
-Update to version 2.10.0. While there are no dedicated release notes, you can review the code changes in Github: https://github.com/libguestfs/virt-v2v/tree/v2.10.0
+`virt-v2v` has been updated to version 2.10.0.
+The code changes are available at https://github.com/libguestfs/virt-v2v/tree/v2.10.0.
 
-- Implement --parallel=N for parallel disk copies
-- Update Translations
-- Various fixes
+- Implement `--parallel=N` for parallel disk copies.
+- Update translations.
+- Various fixes.
 
-===== `virtiofsd`
+==== `virtiofsd`
 
-The `virtiofsd` has been updated to 1.12.0.
+The `virtiofsd` package has been updated to version 1.12.0.
 
-===== `virt-manager`
+==== `virt-manager`
 
-`virt-manager` is now shipped in version 5.1.0. Its preferable to setup VNC for remote viewing and do all the XML editing using the `virsh` command.
-Full list of changes is available at https://github.com/virt-manager/virt-manager/releases/tag/v5.1.0
+`virt-manager` is now shipped in version 5.1.0.
+Using VNC for remote viewing and editing XML configuration directly with the `virsh` command is recommended.
+The full list of changes is available at https://github.com/virt-manager/virt-manager/releases/tag/v5.1.0.
 
-include::../shared.adoc[tags=jscped-15932,leveloffset=+4]
+==== virt-bridge-setup
 
-===== virt-bridge-setup
-
-virt-bridge-setup is a script designed to simplify network bridge creation on a specified interface using nmcli. It was developed as a replacement for the automatic "yast2 virtualization" bridge creation and is particularly useful for setting up virtualization environments.
+`virt-bridge-setup` is a script designed to simplify network bridge creation on a specified interface using `nmcli`.
+It was developed as a replacement for the automatic `yast2 virtualization` bridge creation and is particularly useful for setting up virtualization environments.
 
 Important considerations:
 
 * It supports IPv4 only.
-* This is a simple script not intended for complex network scenarios (vlan, bonding, etc...); manual bridge setup is recommended for intricate configurations.
+* This is a simple script not intended for complex network scenarios (VLAN, bonding, etc.).
+* Manual bridge setup is recommended for intricate configurations.
 * The script should be run locally (not remotely) immediately after installation and before any custom network configurations.
 
 


### PR DESCRIPTION
Fixes the out-of-sequence section header levels and removes the duplicate Kiwi KubeVirt containerdisk format include from the virtualization section (it is already included under Changes affecting all architectures on line 271). Also improves grammar, tone, and formatting.