### PR TITLE
SLES 16.0: Remove erofs from blacklist (jsc#PED-15863)

### DIFF
--- a/adoc/sles/release-notes-sles-160-docinfo.xml
+++ b/adoc/sles/release-notes-sles-160-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xml:id="revhistory" xmlns:xlink="http://www.w3.org/1999/xlink">
     <revision>
+     <date>2026-07-21</date>
+     <revdescription>
+      <itemizedlist>
+       <listitem>
+        <para>Added section <link xlink:href="index.html#jsc-PED-15863">`erofs` removed from the kernel module blacklist</link> (jsc#PED-15863)</para>
+       </listitem>
+      </itemizedlist>
+     </revdescription>
+    </revision>
+    <revision>
      <date>2026-07-20</date>
      <revdescription>
       <itemizedlist>

--- a/adoc/sles/release-notes-sles-160.adoc
+++ b/adoc/sles/release-notes-sles-160.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version160.adoc[]
 
 = SUSE Linux Enterprise Server Release Notes
-:revdate: 2026-07-20
+:revdate: 2026-07-21
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/sles/version160.adoc
+++ b/adoc/sles/version160.adoc
@@ -180,6 +180,16 @@ See <<jsc-PED-6311>>.
 // jsc#PED-11656
 * We now provide a unified image that can be used to install either {slesa} or {slessapa}
 
+[#jsc-PED-15863]
+=== `erofs` removed from the kernel module blacklist
+
+The `erofs` filesystem has been developed and maintained upstream.
+It has been removed from the kernel module blacklist in `suse-module-tools` and is now loaded automatically without explicit manual authorization.
+This prevents loading failures in container and automated environments.
+In `supported.conf`, `erofs` remains classified as unsupported (`-`) as it is not actively developed locally.
+As a result, the `erofs` module is packaged in `kernel-default-extra`.
+Security fixes are actively backported.
+
 // jsc#PED-15435
 include::../shared.adoc[tags=jscped-15435,leveloffset=+2]
 


### PR DESCRIPTION
This pull request adds the SLES 16.0 release note for removing `erofs` from the `suse-module-tools` blacklist (jsc#PED-15863).