### PR TITLE
SLES 16.1, SLES 16.2: Add SSSD deprecation and removal notices (jsc#PED-16257)

### DIFF
--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -15,6 +15,9 @@
     <revdescription>
      <itemizedlist>
       <listitem>
+       <para>SSSD: added deprecation notice for features and options planned for removal in 16.2 (<link xlink:href="index.html#deprecated">jsc#PED-16257</link>)</para>
+      </listitem>
+      <listitem>
        <para>Documented refactored clustering packages for Immutable Mode (<link xlink:href="index.html#jsc-PED-14688">jsc#PED-14688</link>)</para>
       </listitem>
       <listitem>

--- a/adoc/sles/release-notes-sles-162-docinfo.xml
+++ b/adoc/sles/release-notes-sles-162-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-07-21</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>SSSD: added removal notice for features and options removed in 16.2 (<link xlink:href="index.html#removed">jsc#PED-16257</link>)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-07-10</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/sles/release-notes-sles-162.adoc
+++ b/adoc/sles/release-notes-sles-162.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version162.adoc[]
 
 = SUSE Linux Enterprise Server Release Notes
-:revdate: 2026-07-10
+:revdate: 2026-07-21
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -509,6 +509,14 @@ This section lists features and packages that were removed from {productname} or
 
 The following features and packages are deprecated and will be removed in a future version of {productname}.
 
+// jsc#PED-16257
+* The following SSSD features and options are deprecated in {productname} 16.1 and are planned for removal in {productname} 16.2:
+** The enumeration feature for the AD or IPA provider
+** The `sss_ssh_knownhostsproxy` tool
+** The `files` provider
+** The `ad_allow_remote_domain_local_groups` option
+** The `default_domain_suffix` option
+
 // jsc#PED-16439
 * Support for AF_ALG sockets (the `CONFIG_CRYPTO_USER_API` kernel configuration) is deprecated in {productname} 16.1 and will be removed in {productname} 16.2.
 

--- a/adoc/sles/version162.adoc
+++ b/adoc/sles/version162.adoc
@@ -143,6 +143,14 @@ This section lists features and packages that were removed from {productname} or
 
 The following features and packages have been removed in this release.
 
+// jsc#PED-16257
+* The following SSSD features and options have been removed in {productname} 16.2:
+** The enumeration feature for the AD or IPA provider
+** The `sss_ssh_knownhostsproxy` tool
+** The `files` provider
+** The `ad_allow_remote_domain_local_groups` option
+** The `default_domain_suffix` option
+
 // jsc#PED-16439
 * Support for AF_ALG sockets (the `CONFIG_CRYPTO_USER_API` kernel configuration) has been removed.
 


### PR DESCRIPTION
This PR documents the SSSD features and options that are deprecated in SLES 16.1 and planned for removal in SLES 16.2.