### PR TITLE
SLES 16.0, 16.1: Deprecate and remove UDP-Lite (jsc#PED-16118)

### DIFF
--- a/adoc/sles/release-notes-sles-160-docinfo.xml
+++ b/adoc/sles/release-notes-sles-160-docinfo.xml
@@ -15,6 +15,9 @@
      <revdescription>
       <itemizedlist>
        <listitem>
+        <para>Added deprecation notice for UDP-Lite protocol (<link xlink:href="index.html#deprecated">jsc#PED-16118</link>)</para>
+       </listitem>
+       <listitem>
         <para>Added section <link xlink:href="index.html#jsc-PED-15863">`erofs` removed from the kernel module blacklist</link> (jsc#PED-15863)</para>
        </listitem>
       </itemizedlist>

--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -15,6 +15,9 @@
     <revdescription>
      <itemizedlist>
       <listitem>
+       <para>Documented disabled UDP-Lite protocol (<link xlink:href="index.html#removed">jsc#PED-16118</link>)</para>
+      </listitem>
+      <listitem>
        <para>SSSD: added deprecation notice for features and options planned for removal in 16.2 (<link xlink:href="index.html#deprecated">jsc#PED-16257</link>)</para>
       </listitem>
       <listitem>

--- a/adoc/sles/version160.adoc
+++ b/adoc/sles/version160.adoc
@@ -1309,6 +1309,10 @@ include::../shared.adoc[tags=jscped12374]
 
 The following features and packages are deprecated and will be removed in a future version of {productname}.
 
+// jsc#PED-16118
+* The UDP-Lite protocol (RFC 3828) is deprecated in {productname} 16.0 and will be disabled in {productname} 16.1.
+  This protocol is being dropped from the upstream Linux kernel.
+
 // jsc-PED-12744
 * The 2MB OVMF image will be deprecated and removed in {productname} 16.1.
 // * <<jsc-PED-12189>>

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -492,10 +492,14 @@ This section lists features and packages that were removed from {productname} or
 // For more information about all package and module changes since the last version, see <<intro-package-changes>>.
 
 
-// [#removed]
-// === Removed features and packages
+[#removed]
+=== Removed features and packages
 
-// The following features and packages have been removed in this release.
+The following features and packages have been removed in this release.
+
+// jsc#PED-16118
+* The UDP-Lite protocol (RFC 3828) has been disabled in the {productname} 16.1 kernel.
+  This protocol has been dropped from the upstream Linux kernel.
 
 
 [#deprecated]


### PR DESCRIPTION
This PR adds the deprecation notice for UDP-Lite in SLES 16.0 and the actual removal notice in SLES 16.1.

Addresses: https://jira.suse.com/browse/PED-16118