### PR TITLE
SLES 16.0, SL Micro 6.2: Add note about post-quantum cryptography support (jsc#PED-15713)

### DIFF
--- a/adoc/micro/release-notes-micro-62-docinfo.xml
+++ b/adoc/micro/release-notes-micro-62-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-07-21</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Post-quantum cryptography (PQC) key exchange enabled by default (<link xlink:href="index.html#jsc-PED-15713">jsc#PED-15713</link>)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-07-17</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/micro/release-notes-micro-62.adoc
+++ b/adoc/micro/release-notes-micro-62.adoc
@@ -4,7 +4,7 @@ include::attributes.adoc[]
 :this-version: 6.2
 
 = SL Micro Release Notes
-:revdate: 2026-07-17
+:revdate: 2026-07-21
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/micro/version62.adoc
+++ b/adoc/micro/version62.adoc
@@ -15,6 +15,9 @@ These release notes apply to {productname} {this-version}.
 // jsc#PED-11013
 * {ulp} is now supported with transactional updates
 
+// Post-quantum cryptography enabled by default
+include::../shared.adoc[tags=jscped-15713,leveloffset=+3]
+
 // jsc#PED-12879
 include::../shared.adoc[tags=jscped-12879,leveloffset=+3]
 

--- a/adoc/shared.adoc
+++ b/adoc/shared.adoc
@@ -319,3 +319,12 @@ tag::jscped-16001[]
 The `iptables` and `nftables` packages have been added to SLES Minimal Cloud and VMware VM images.
 This addition enables the successful provisioning of Rancher-deployed RKE2 and K3s clusters on SLES Minimal images without requiring manual package installation or Subscription Management (RMT) registration.
 end::jscped-16001[]
+
+tag::jscped-15713[]
+[#jsc-PED-15713]
+= Post-quantum cryptography (PQC) key exchange enabled by default
+
+By default, system-wide cryptographic policies now enable post-quantum cryptography (PQC) key exchange algorithms for SSH connections.
+This prevents connection warnings (such as `WARNING: connection is not using a post-quantum key exchange algorithm`) from modern external SSH clients that require post-quantum security by default.
+This support is provided by re-enabling the X25519 key exchange group in the default system-wide cryptographic policy, which allows secure post-quantum key exchange combinations such as `mlkem768x25519-sha256` and `sntrup761x25519-sha512` to be negotiated.
+end::jscped-15713[]

--- a/adoc/sles/release-notes-sles-160-docinfo.xml
+++ b/adoc/sles/release-notes-sles-160-docinfo.xml
@@ -23,6 +23,9 @@
        <listitem>
         <para>Added section <link xlink:href="index.html#jsc-PED-15863">`erofs` removed from the kernel module blacklist</link> (jsc#PED-15863)</para>
        </listitem>
+       <listitem>
+        <para>Added section <link xlink:href="index.html#jsc-PED-15713">Post-quantum cryptography (PQC) key exchange enabled by default</link> (jsc#PED-15713)</para>
+       </listitem>
       </itemizedlist>
      </revdescription>
     </revision>

--- a/adoc/sles/version160.adoc
+++ b/adoc/sles/version160.adoc
@@ -180,6 +180,9 @@ See <<jsc-PED-6311>>.
 // jsc#PED-11656
 * We now provide a unified image that can be used to install either {slesa} or {slessapa}
 
+// jsc#PED-15713
+include::../shared.adoc[tags=jscped-15713,leveloffset=+2]
+
 // jsc#PED-16001
 include::../shared.adoc[tags=jscped-16001,leveloffset=+2]
 


### PR DESCRIPTION
This PR adds the release notes for post-quantum cryptography (PQC) key exchange default enablement in system-wide crypto policies for SLES 16.0 and SL Micro 6.2. Closes jsc#PED-15713.