### PR TITLE
SLES 16.0: Add note about Node.js 24 default version (jsc#PED-15471)

### DIFF
--- a/adoc/sles/release-notes-sles-160-docinfo.xml
+++ b/adoc/sles/release-notes-sles-160-docinfo.xml
@@ -15,6 +15,9 @@
      <revdescription>
       <itemizedlist>
        <listitem>
+        <para>Added section <link xlink:href="index.html#jsc-PED-15471">Node.js 24 is now the default version</link> (jsc#PED-15471)</para>
+       </listitem>
+       <listitem>
         <para>Added section <link xlink:href="index.html#jsc-PED-16001">Added iptables and nftables to SLES Minimal images</link> (jsc#PED-16001)</para>
        </listitem>
        <listitem>

--- a/adoc/sles/version160.adoc
+++ b/adoc/sles/version160.adoc
@@ -180,6 +180,14 @@ See <<jsc-PED-6311>>.
 // jsc#PED-11656
 * We now provide a unified image that can be used to install either {slesa} or {slessapa}
 
+[#jsc-PED-15471]
+=== Node.js 24 is now the default version
+
+The `nodejs24` package is included as the default Node.js version in {productname} {this-version}.
+The `nodejs-common` package has been configured so that the default `nodejs` and `npm` commands point to Node.js 24.
+Node.js 24 is an LTS version and is supported upstream until April 2028.
+
+
 // jsc#PED-15713
 include::../shared.adoc[tags=jscped-15713,leveloffset=+2]
 


### PR DESCRIPTION
This pull request adds SLES 16.0 release notes for the Node.js 24 default version update under the 'Changes affecting all architectures' section, adhering to the one-sentence-per-line rule and placing the note at the very top of the titled sections.