### PR TITLE
SLES 16.0, SLES 16.1: Document DCCP protocol removal (jsc#PED-16117)

### DIFF
--- a/adoc/sles/release-notes-sles-160-docinfo.xml
+++ b/adoc/sles/release-notes-sles-160-docinfo.xml
@@ -15,6 +15,9 @@
      <revdescription>
       <itemizedlist>
        <listitem>
+        <para>Added deprecation notice for DCCP protocol (<link xlink:href="index.html#deprecated">jsc#PED-16117</link>)</para>
+       </listitem>
+       <listitem>
         <para>Added section <link xlink:href="index.html#jsc-PED-15471">Node.js 24 is now the default version</link> (jsc#PED-15471)</para>
        </listitem>
        <listitem>

--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -15,6 +15,9 @@
     <revdescription>
      <itemizedlist>
       <listitem>
+       <para>Documented disabled DCCP protocol (<link xlink:href="index.html#removed">jsc#PED-16117</link>)</para>
+      </listitem>
+      <listitem>
        <para>Added section <link xlink:href="index.html#jsc-PED-16001">Added iptables and nftables to SLES Minimal images</link> (jsc#PED-16001)</para>
       </listitem>
       <listitem>

--- a/adoc/sles/version160.adoc
+++ b/adoc/sles/version160.adoc
@@ -1323,6 +1323,10 @@ include::../shared.adoc[tags=jscped12374]
 
 The following features and packages are deprecated and will be removed in a future version of {productname}.
 
+// jsc#PED-16117
+* The DCCP protocol is deprecated in {productname} 16.0 and will be disabled in {productname} 16.1.
+  This protocol is being dropped from the upstream Linux kernel.
+
 // jsc#PED-16118
 * The UDP-Lite protocol (RFC 3828) is deprecated in {productname} 16.0 and will be disabled in {productname} 16.1.
   This protocol is being dropped from the upstream Linux kernel.

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -500,6 +500,10 @@ This section lists features and packages that were removed from {productname} or
 
 The following features and packages have been removed in this release.
 
+// jsc#PED-16117
+* The DCCP protocol has been disabled in the {productname} 16.1 kernel.
+  This protocol has been dropped from the upstream Linux kernel.
+
 // jsc#PED-16118
 * The UDP-Lite protocol (RFC 3828) has been disabled in the {productname} 16.1 kernel.
   This protocol has been dropped from the upstream Linux kernel.


### PR DESCRIPTION
This PR documents the planned deprecation of the DCCP protocol in SLES 16.0, and its actual removal in SLES 16.1, adhering to the Deprecation and Removal Double Notice pattern.