### PR TITLE
SLES 16.2: Add note about GNU patch version 2.8 update (jsc#PED-16669)

### DIFF
--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-07-22</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Added note about upcoming GNU patch update to version 2.8 in 16.2 (<link xlink:href="index.html#jsc-PED-16669-upcoming">jsc#PED-16669</link>)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-07-21</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/sles/release-notes-sles-161.adoc
+++ b/adoc/sles/release-notes-sles-161.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version161.adoc[]
 
 = SUSE Linux Enterprise Server Release Notes
-:revdate: 2026-07-21
+:revdate: 2026-07-22
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/sles/release-notes-sles-162-docinfo.xml
+++ b/adoc/sles/release-notes-sles-162-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-07-22</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Added note about GNU patch updated to version 2.8 (<link xlink:href="index.html#jsc-PED-16669">jsc#PED-16669</link>)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-07-21</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/sles/release-notes-sles-162.adoc
+++ b/adoc/sles/release-notes-sles-162.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version162.adoc[]
 
 = SUSE Linux Enterprise Server Release Notes
-:revdate: 2026-07-21
+:revdate: 2026-07-22
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -186,6 +186,15 @@ include::../shared.adoc[tags=jscped-15282,leveloffset=+2]
 // bsc#1271333
 include::../shared.adoc[tags=bsc1271333,leveloffset=+2]
 
+[#jsc-PED-16669-upcoming]
+=== Upcoming update of GNU `patch` to version 2.8 in {productname} 16.2
+
+The GNU `patch` package will be updated to version 2.8 in {productname} 16.2.
+For a complete list of upcoming changes, see the link:https://savannah.gnu.org/news/?id=10741[GNU patch release announcement].
+
+GNU `patch` version 2.8 enforces stricter header parsing.
+Ensure patch-generating tools do not inject `NUL` bytes or raw control characters into header lines or diff directives, as they are no longer accepted in version 2.8.
+
 [#jsc-PED-15707]
 === Login hint when attempting root login to {cockpit}
 

--- a/adoc/sles/version162.adoc
+++ b/adoc/sles/version162.adoc
@@ -105,7 +105,16 @@ Technology previews come with the following limitations:
 There are no technology previews at this time.
 
 
-// == Changes affecting all architectures
+== Changes affecting all architectures
+
+[#jsc-PED-16669]
+=== GNU `patch` updated to version 2.8
+
+The GNU `patch` package has been updated to version 2.8 in {productname} 16.2.
+For a complete list of changes, see the link:https://savannah.gnu.org/news/?id=10741[GNU patch release announcement].
+
+GNU `patch` version 2.8 enforces stricter header parsing.
+Ensure patch-generating tools do not inject `NUL` bytes or raw control characters into header lines or diff directives, as they are no longer accepted.
 
 
 // == {x64}-specific changes


### PR DESCRIPTION
This PR documents the upcoming update of the GNU patch package to version 2.8 in SLES 16.2, detailing potential incompatibilities such as stricter header parsing and NUL byte rejection as tracked in [PED-16669](https://jira.suse.com/browse/PED-16669).