### PR TITLE
SLES 16.1, SL Micro 6.2: Add note about firewalld default presets (jsc#PED-4973)

### DIFF
--- a/adoc/micro/release-notes-micro-62-docinfo.xml
+++ b/adoc/micro/release-notes-micro-62-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-07-22</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Added section <link xlink:href="index.html#jsc-PED-4973">Firewalld default presets</link> (jsc#PED-4973)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-07-21</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/micro/release-notes-micro-62.adoc
+++ b/adoc/micro/release-notes-micro-62.adoc
@@ -4,7 +4,7 @@ include::attributes.adoc[]
 :this-version: 6.2
 
 = SL Micro Release Notes
-:revdate: 2026-07-21
+:revdate: 2026-07-22
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/micro/version62.adoc
+++ b/adoc/micro/version62.adoc
@@ -15,6 +15,9 @@ These release notes apply to {productname} {this-version}.
 // jsc#PED-11013
 * {ulp} is now supported with transactional updates
 
+// jsc#PED-4973
+include::../shared.adoc[tags=jscped-4973,leveloffset=+3]
+
 // Post-quantum cryptography enabled by default
 include::../shared.adoc[tags=jscped-15713,leveloffset=+3]
 

--- a/adoc/shared.adoc
+++ b/adoc/shared.adoc
@@ -1,3 +1,12 @@
+tag::jscped-4973[]
+[#jsc-PED-4973]
+= Firewalld default presets
+
+To ensure consistent security and management preset behavior, `firewalld` is now enabled by default.
+This unification aligns the default service states across standard and immutable operating modes on {productname} {this-version}.
+You can customize the firewalld presets or disable the service if necessary.
+end::jscped-4973[]
+
 tag::bsc1271333[]
 [#bsc-1271333]
 = XFS log stripe unit alignment change

--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -15,6 +15,9 @@
     <revdescription>
      <itemizedlist>
       <listitem>
+       <para>Added section <link xlink:href="index.html#jsc-PED-4973">Firewalld default presets</link> (jsc#PED-4973)</para>
+      </listitem>
+      <listitem>
        <para>Added note about upcoming GNU patch update to version 2.8 in 16.2 (<link xlink:href="index.html#jsc-PED-16669-upcoming">jsc#PED-16669</link>)</para>
       </listitem>
      </itemizedlist>

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -168,6 +168,9 @@ See <<jsc-PED-16106>>.
 // jsc#PED-12658
 * `rasdaemon` has been updated to version 0.8.4. This version supports machine checks related to CXL memory. Since Intel® Optane™ Memory products have reached End of Life (EOL), {productname} {this-version} does not support them either.
 
+// jsc#PED-4973
+include::../shared.adoc[tags=jscped-4973,leveloffset=+2]
+
 // jsc#PED-16001
 include::../shared.adoc[tags=jscped-16001,leveloffset=+2]
 


### PR DESCRIPTION
Address PED-4973: Document firewalld default presets for SLES 16.1 and SL Micro 6.2.