### PR TITLE
SL Micro 6.2: Add note about adding sensors package (jsc#SMO-578)

### DIFF
--- a/adoc/micro/release-notes-micro-62-docinfo.xml
+++ b/adoc/micro/release-notes-micro-62-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-07-24</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>The `sensors` package has been added to the repositories (jsc#SMO-578)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-07-22</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/micro/release-notes-micro-62.adoc
+++ b/adoc/micro/release-notes-micro-62.adoc
@@ -4,7 +4,7 @@ include::attributes.adoc[]
 :this-version: 6.2
 
 = SL Micro Release Notes
-:revdate: 2026-07-22
+:revdate: 2026-07-24
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/micro/version62.adoc
+++ b/adoc/micro/version62.adoc
@@ -10,6 +10,8 @@ These release notes apply to {productname} {this-version}.
 
 === Changes affecting all architectures
 
+// jsc#SMO-578
+* The `sensors` package has been added to the repositories, enabling the monitoring of hardware temperatures, voltage, and fan speeds.
 // jsc-SMO-573
 * Image re-encryption during the OS initialisation is now faster
 // jsc#PED-11013


### PR DESCRIPTION
Add release note for adding the sensors package in SLE Micro 6.2. This corresponds to SMO-578.