### PR TITLE
SLES 16.1: Relocate stress-ng back to SUSE Package Hub (jsc#PED-16698)

### DIFF
--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-07-24</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Documented relocation of stress-ng back to SUSE Package Hub (<link xlink:href="index.html#removed">jsc#PED-16698</link>)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-07-22</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/sles/release-notes-sles-161.adoc
+++ b/adoc/sles/release-notes-sles-161.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version161.adoc[]
 
 = SUSE Linux Enterprise Server Release Notes
-:revdate: 2026-07-22
+:revdate: 2026-07-24
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -512,6 +512,10 @@ This section lists features and packages that were removed from {productname} or
 
 The following features and packages have been removed in this release.
 
+// jsc#PED-16698
+* The `stress-ng` package has been relocated from {productname} back to {ph}.
+  Consequently, it is no longer officially supported as part of the core product.
+
 // jsc#PED-16117
 * The DCCP protocol has been disabled in the {productname} 16.1 kernel.
   This protocol has been dropped from the upstream Linux kernel.


### PR DESCRIPTION
This pull request documents the relocation of the 'stress-ng' package from the SLES 16.1 Main Product back to SUSE Package Hub (PackageHub) due to its unmaintained status and lack of a clear business requirement.