### PR TITLE
SLES 16.1: Document removal of perl-Test-Output package (jsc#PED-16555)

### DIFF
--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -15,6 +15,9 @@
     <revdescription>
      <itemizedlist>
       <listitem>
+       <para>Documented removal of perl-Test-Output package (<link xlink:href="index.html#removed">jsc#PED-16555</link>)</para>
+      </listitem>
+      <listitem>
        <para>Documented relocation of stress-ng back to SUSE Package Hub (<link xlink:href="index.html#removed">jsc#PED-16698</link>)</para>
       </listitem>
      </itemizedlist>

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -512,6 +512,9 @@ This section lists features and packages that were removed from {productname} or
 
 The following features and packages have been removed in this release.
 
+// jsc#PED-16555
+* The `perl-Test-Output` package has been removed from {productname} 16.1 due to its unmaintained status.
+
 // jsc#PED-16698
 * The `stress-ng` package has been relocated from {productname} back to {ph}.
   Consequently, it is no longer officially supported as part of the core product.


### PR DESCRIPTION
Documents the removal of the perl-Test-Output package from SLES 16.1 due to its unmaintained status. Addresses issue: https://jira.suse.com/browse/PED-16555