### PR TITLE
SLES 16.0 KVM: Redefined UEFI KVM VMs fail to start (bsc#1271635)

### DIFF
--- a/adoc/sles/release-notes-sles-160-docinfo.xml
+++ b/adoc/sles/release-notes-sles-160-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xml:id="revhistory" xmlns:xlink="http://www.w3.org/1999/xlink">
     <revision>
+     <date>2026-07-27</date>
+     <revdescription>
+      <itemizedlist>
+       <listitem>
+        <para>Redefined UEFI KVM virtual machines fail to start (<link xlink:href="index.html#bsc-1271635">bsc#1271635</link>)</para>
+       </listitem>
+      </itemizedlist>
+     </revdescription>
+    </revision>
+    <revision>
      <date>2026-07-21</date>
      <revdescription>
       <itemizedlist>

--- a/adoc/sles/release-notes-sles-160.adoc
+++ b/adoc/sles/release-notes-sles-160.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version160.adoc[]
 
 = SUSE Linux Enterprise Server Release Notes
-:revdate: 2026-07-21
+:revdate: 2026-07-27
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/sles/version160.adoc
+++ b/adoc/sles/version160.adoc
@@ -842,6 +842,14 @@ The configured NTP settings are written to the target system to persist after in
 
 Information in this section applies to the {x64} architecture.
 
+[#bsc-1271635]
+=== Redefined UEFI KVM virtual machines fail to start
+
+UEFI KVM virtual machines created with `--cpu host-model` fail to start after a redefine operation.
+This is caused by a missing `pdcm` CPU feature check during startup.
+To work around this issue, remove `<feature policy='disable' name='pdcm'/>` from the domain XML of the virtual machine.
+Alternatively, avoid using `--cpu host-model` for virtual machines that require migration or redefine operations.
+
 [#jsc-PED-11640]
 === AMD EPYC Turin automonous frequency scaling
 


### PR DESCRIPTION
This PR adds a release note and workaround for bsc#1271635 regarding the missing KVM pdcm CPU feature when virtual machines created with host-model are redefined.