### PR TITLE
SLES 16.1: Document SDL 3 update and legacy SDL2 package removal (jsc#PED-14453)

### DIFF
--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-07-27</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Documented SDL 3 update and legacy SDL2 package removal (<link xlink:href="index.html#jsc-PED-14453">jsc#PED-14453</link>)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-07-24</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/sles/release-notes-sles-161.adoc
+++ b/adoc/sles/release-notes-sles-161.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version161.adoc[]
 
 = SUSE Linux Enterprise Server Release Notes
-:revdate: 2026-07-24
+:revdate: 2026-07-27
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -189,6 +189,13 @@ include::../shared.adoc[tags=jscped-15282,leveloffset=+2]
 // bsc#1271333
 include::../shared.adoc[tags=bsc1271333,leveloffset=+2]
 
+[#jsc-PED-14453]
+=== SDL 3 and sdl2-compat update
+
+{productname} {this-version} includes Simple DirectMedia Layer 3 (SDL 3).
+Compatibility for SDL 2.0 applications is now provided through the `sdl2-compat` library layer.
+The legacy `SDL2` package has been removed.
+
 [#jsc-PED-16669-upcoming]
 === Upcoming update of GNU `patch` to version 2.8 in {productname} 16.2
 
@@ -511,6 +518,10 @@ This section lists features and packages that were removed from {productname} or
 === Removed features and packages
 
 The following features and packages have been removed in this release.
+
+// jsc#PED-14453
+* The legacy `SDL2` package has been removed in favor of `sdl2-compat` and the newer `SDL3` package.
+  Applications relying on SDL 2.0 now utilize the `sdl2-compat` compatibility layer.
 
 // jsc#PED-16696
 // jsc#PED-16555


### PR DESCRIPTION
This PR adds the release notes for SLES 16.1 regarding the transition to Simple DirectMedia Layer 3 (SDL 3) and the compatibility layer (sdl2-compat), as well as the corresponding removal of the legacy SDL2 package.

Jira: https://jira.suse.com/browse/PED-14453