### PR TITLE
SLE Micro 6.1: Add release note for robust PXE boot installations (jsc#PED-8790)

### DIFF
--- a/adoc/micro/release-notes-micro-61.adoc
+++ b/adoc/micro/release-notes-micro-61.adoc
@@ -4,7 +4,7 @@ include::attributes.adoc[]
 :this-version: 6.1
 
 = SL Micro Release Notes
-:revdate: 2026-07-17
+:revdate: 2026-07-28
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/micro/version61.adoc
+++ b/adoc/micro/version61.adoc
@@ -23,10 +23,19 @@ include::../shared.adoc[tags=jscped-12860,leveloffset=+3]
 // SHA1 disabled
 include::../shared.adoc[tags=jscped-12210,leveloffset=+3]
 
+[#jsc-PED-8790]
+==== Robust PXE Boot installations
+
+Network deployment of raw disk images via the {kiwi} PXE boot self-installer has been improved.
+Invalid or inaccessible remote image URLs now trigger detailed, readable error messages.
+Error logs are preserved for troubleshooting instead of being discarded.
+The image download mechanism now automatically reconnects on slow networks to prevent timeouts.
+
 ==== Installation media
 
 // jsc#PED-8578
-On top of the images described above with {productname} {this-version} we are adding PXE boot images (network boot .tar) for all architectures except ppc64le.
+On top of the images described above with {productname} {this-version} we are adding PXE boot images (network boot .tar) for all architectures except {ppc64le}.
+For information about improvements to PXE boot installation reliability, see <<jsc-PED-8790>>.
 
 ==== Supported Architectures
 


### PR DESCRIPTION
Document robust PXE boot installation improvements under PED-8790.