### PR TITLE
SLES 16.1, SLES for SAP 16.1: Clean up IBM 3480/3590 tape drive removal note (jsc#DOCTEAM-2356)

### DIFF
--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-07-28</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Documented removed support for IBM 3480 and 3590 tape drives on IBM Z (<link xlink:href="index.html#bsc-1266763">bsc#1266763</link>)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-07-27</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/sles/release-notes-sles-161.adoc
+++ b/adoc/sles/release-notes-sles-161.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version161.adoc[]
 
 = SUSE Linux Enterprise Server Release Notes
-:revdate: 2026-07-27
+:revdate: 2026-07-28
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -414,9 +414,15 @@ include::../kernel-161-aarch64.adoc[leveloffset=+2]
 Information in this section applies to {z-productname}.
 For more information, see https://www.ibm.com/docs/en/linux-on-systems?topic=distributions-suse-linux-enterprise-server
 
-=== Removed support for tape drives === 
-Removed support for IBM 3480 and 3590 tape drives incl. tape390_display and tape390_crypt tools. 
-This is consistent with the changes introduced in s390-tools, where support for 3480 and 3590 FICON tape devices as well as the related tape390 utilities was removed, while other tape technologies remain outside the scope of this statement. There are virtual tape servers (emulated tape like IBM TS7700 Virtual Tape Server) which continue to be served by tape.ko & tape_34xx.ko (& tape_3590.ko).
+// jsc#PED-14585
+// jsc#DOCTEAM-2356
+[#bsc-1266763]
+=== Removed support for IBM 3480 and 3590 tape drives
+
+Support for IBM 3480 and 3590 tape drives, including the `tape390_display` and `tape390_crypt` tools, has been removed.
+In `s390-tools`, support for 3480 and 3590 FICON tape devices as well as the related `tape390` utilities is removed.
+Other tape technologies are not affected by this removal.
+Virtual tape servers, such as the emulated IBM TS7700 Virtual Tape Server, continue to be supported via the `tape.ko`, `tape_34xx.ko`, and `tape_3590.ko` kernel modules.
 
 include::../shared.adoc[tag=jscped-15968,leveloffset=+2]
 

--- a/adoc/slesap/release-notes-slesap-161-docinfo.xml
+++ b/adoc/slesap/release-notes-slesap-161-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xml:id="revhistory" xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-07-28</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Documented removed support for IBM 3480 and 3590 tape drives on IBM Z (<link xlink:href="index.html#bsc-1266763">bsc#1266763</link>)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-07-17</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/slesap/release-notes-slesap-161.adoc
+++ b/adoc/slesap/release-notes-slesap-161.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version161.adoc[]
 
 = {productname} Release Notes
-:revdate: 2026-07-17
+:revdate: 2026-07-28
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.


### PR DESCRIPTION
Clean up the merged tape drive removal release note to adhere to the required standards:
- Adheres to 'one sentence per line' formatting.
- Replaces plain-text tracker IDs with comment references above the heading.
- Formats tools and kernel modules with backticks.
- Updates master file revision dates and revision histories in docinfo.xml.

Ref: bsc#1266763, jsc#PED-14585, jsc#DOCTEAM-2356