### PR TITLE
SLES 16.1: Automated provisioning with cloud-init in virtual machine guest images (jsc#PED-15378)

### DIFF
--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -17,6 +17,9 @@
       <listitem>
        <para>Documented removed support for IBM 3480 and 3590 tape drives on IBM Z (<link xlink:href="index.html#bsc-1266763">bsc#1266763</link>)</para>
       </listitem>
+      <listitem>
+       <para>Added section <link xlink:href="index.html#jsc-PED-15378">Automated provisioning with cloud-init in virtual machine guest images</link> (jsc#PED-15378)</para>
+      </listitem>
      </itemizedlist>
     </revdescription>
   </revision>

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -426,9 +426,17 @@ Virtual tape servers, such as the emulated IBM TS7700 Virtual Tape Server, conti
 
 include::../shared.adoc[tag=jscped-15968,leveloffset=+2]
 
-// == POWER-specific changes (ppc64le)
+[#power]
+== POWER-specific changes (ppc64le)
 
-// Information in this section applies to {power-productname}.
+Information in this section applies to {power-productname}.
+
+[#jsc-PED-15378]
+=== Automated provisioning with cloud-init in virtual machine guest images
+
+The raw and qcow2 virtual machine guest images for the {power} architecture ({ppc64le}) are now built with cloud-init integration.
+Previously, provisioning virtual machines on KVM using these images required manual configuration steps.
+Automated initial guest provisioning is now fully supported.
 
 // == {arm}-specific changes ({aarch64})
 


### PR DESCRIPTION
Integrate release note for PED-15378: support for cloud-init based provisioning in KVM guest raw/qcow2 images on ppc64le.