### PR TITLE
CI: Cancel in-flight previews when PR is closed or merged

### DIFF
--- a/.github/workflows/asciidoc.yml
+++ b/.github/workflows/asciidoc.yml
@@ -12,6 +12,10 @@ on:
       - ".github/workflows/*"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/scripts/comment-pr-preview.py
+++ b/scripts/comment-pr-preview.py
@@ -22,6 +22,19 @@ def main():
     pr_number = sys.argv[1]
     repo = sys.argv[2]
 
+    # Check if PR is still open before commenting
+    state_stdout, state_code = run_command([
+        "gh", "pr", "view", pr_number, "--repo", repo, "--json", "state"
+    ])
+    if state_code == 0 and state_stdout:
+        try:
+            state_data = json.loads(state_stdout)
+            if state_data.get("state") != "OPEN":
+                print(f"PR {pr_number} is {state_data.get('state')}. Skipping preview comment.")
+                sys.exit(0)
+        except Exception as e:
+            print(f"Warning: Failed to parse PR state JSON: {e}", file=sys.stderr)
+
     # 1. Read product-registry.yml
     registry_path = ".github/product-registry.yml"
     if not os.path.exists(registry_path):


### PR DESCRIPTION
This PR fixes an issue where the PR preview commenting script runs and posts comments even if a PR was already merged and closed, causing redundant notifications.

It introduces two changes:
1. **Concurrency Group in `asciidoc.yml`**: Prevents redundant in-flight workflows from finishing and commenting if a newer commit is pushed or if the PR is closed (which cancels all previous/running preview runs for that PR).
2. **PR State Check in `comment-pr-preview.py`**: Makes the python script check the status of the PR using `gh pr view` before compiling links/posting a comment. If the PR status is not `OPEN` (e.g. `MERGED` or `CLOSED`), it exits early and skips the comment completely.