### PR TITLE
ci: Optimize PR preview builds with dynamic dependency tracing and caching

### DIFF
--- a/.github/workflows/asciidoc.yml
+++ b/.github/workflows/asciidoc.yml
@@ -17,35 +17,88 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  validate:
+  detect:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.action != 'closed'
+    outputs:
+      affected_dcs: ${{ steps.set-output.outputs.affected_dcs }}
+      has_changes: ${{ steps.set-output.outputs.has_changes }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+      - name: Detect affected DC files
+        id: set-output
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          else
+            BASE_SHA="${{ github.event.before }}"
+            HEAD_SHA="${{ github.event.after }}"
+            if [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ] || [ -z "$BASE_SHA" ]; then
+              BASE_SHA="HEAD^"
+            fi
+          fi
+          
+          echo "Comparing $BASE_SHA to $HEAD_SHA"
+          CHANGED_FILES=$(git diff --name-only $BASE_SHA $HEAD_SHA)
+          
+          AFFECTED=$(echo "$CHANGED_FILES" | uv run scripts/detect-affected-dcs.py)
+          echo "Affected DC files: $AFFECTED"
+          
+          if [ -z "$AFFECTED" ]; then
+            echo "affected_dcs=" >> $GITHUB_OUTPUT
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "affected_dcs=$AFFECTED" >> $GITHUB_OUTPUT
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+  validate:
+    runs-on: ubuntu-latest
+    needs: detect
+    if: needs.detect.outputs.has_changes == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: openSUSE/doc-ci@gha-validate
         with:
-          dc-files: "DC-*"
+          dc-files: ${{ needs.detect.outputs.affected_dcs }}
           validate-ids: true
           validate-images: true
           validate-tables: true
+
   build:
     runs-on: ubuntu-latest
-    needs: validate
+    needs: [detect, validate]
+    if: needs.detect.outputs.has_changes == 'true'
     steps:
       - uses: actions/checkout@v4
+      - name: Cache DAPS Build Directory
+        uses: actions/cache@v4
+        with:
+          path: build/
+          key: ${{ runner.os }}-daps-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-daps-${{ github.ref_name }}-
+            ${{ runner.os }}-daps-
       - uses: openSUSE/doc-ci@gha-build
         id: build-dc
         with:
-          dc-files: "DC-*"
+          dc-files: ${{ needs.detect.outputs.affected_dcs }}
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.build-dc.outputs.artifact-name }}
           path: ${{ steps.build-dc.outputs.artifact-dir }}/*
           retention-days: 3
+
   publish:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
-    needs: build
+    needs: [detect, build]
+    if: needs.detect.outputs.has_changes == 'true'
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
@@ -74,7 +127,8 @@ jobs:
     permissions:
       pull-requests: write
       issues: write
-    needs: build
+    needs: [detect, build]
+    if: needs.detect.outputs.has_changes == 'true'
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4

--- a/docs/superpowers/specs/2026-07-28-pr-build-optimization-design.md
+++ b/docs/superpowers/specs/2026-07-28-pr-build-optimization-design.md
@@ -1,0 +1,51 @@
+# PR Build Optimization Design Specification
+
+## Overview
+This document specifies the design for a durable, automatic dependency tracking solution to optimize GitHub Actions PR preview builds. The goal is to only validate and build the specific release note products (`DC-*` files) whose source AsciiDoc files or dependencies have been modified, vastly reducing PR build times.
+
+## Architecture
+
+The solution comprises two main components:
+1. **Dynamic AsciiDoc Include-Tracer:** A Python script that recursively builds a true dependency graph of all `DC-*` files by parsing `include::` directives, mapping changed files to their parent products.
+2. **GitHub Actions Workflow Refactoring:** A `detect` job that determines the git diff and runs the tracer, passing the dynamically filtered list of affected `DC-*` files to the `validate` and `build` jobs. The `build` job will employ `actions/cache` on the DAPS `build/` directory for true incremental compilation.
+
+## 1. Dynamic Dependency Tracer (`scripts/detect-affected-dcs.py`)
+* **Execution:** Reads a list of changed file paths from `stdin`.
+* **Graph Building:** 
+  * Identifies all `DC-*` files in the repository root.
+  * For each `DC-*` file, reads its `MAIN` file path.
+  * Recursively scans `.adoc` files starting from `MAIN`, searching for `include::[.../]<file_path>[\\[.*?\\]]`.
+  * Resolves relative paths relative to the current file's directory.
+  * Also flags sibling `.xml` files (e.g. `docinfo.xml`) and referenced image files as dependencies of the product.
+* **Analysis & Safety Fallback:**
+  * Iterates over the changed files from `stdin`.
+  * If a changed file is determined to be "global" (i.e. not inside `adoc/` and not a `DC-*` file itself, such as `Makefile`, workflows, scripts), the script safely falls back to outputting **all** `DC-*` files to prevent silent breakage.
+  * Otherwise, maps the changed file to all `DC-*` files that depend on it.
+* **Output:** Prints a space-separated string of the affected `DC-*` files to `stdout` and exits.
+
+## 2. GitHub Actions Workflow Integration (`.github/workflows/asciidoc.yml`)
+
+### The `detect` Job
+* **Purpose:** Run early to figure out the exact diff.
+* **Logic:** 
+  * Checks out code with `fetch-depth: 0` to access commit history.
+  * Derives the base SHA and head SHA differently depending on whether it's a `pull_request` event or `push` event.
+  * Runs `git diff --name-only $BASE_SHA $HEAD_SHA | uv run scripts/detect-affected-dcs.py`.
+  * Passes the output into job outputs: `affected_dcs` and `has_changes` (boolean).
+
+### The Cache Strategy
+* **Location:** The DAPS compilation target `build/`.
+* **Action:** Uses `actions/cache@v4` in the `build` job.
+* **Keys:**
+  * Cache Key: `${{ runner.os }}-daps-${{ github.ref_name }}-${{ github.sha }}`
+  * Restore Keys: `${{ runner.os }}-daps-${{ github.ref_name }}-` -> `${{ runner.os }}-daps-`
+* **Effect:** When compiling the limited set of affected DC files, DAPS will find the previously compiled XML/HTML assets in `build/` and only update what has actually changed.
+
+### The `validate` and `build` Jobs
+* Conditioned to run `if: needs.detect.outputs.has_changes == 'true'`.
+* Both receive `dc-files: ${{ needs.detect.outputs.affected_dcs }}` instead of the hardcoded `"DC-*"`.
+
+## Error Handling & Edge Cases
+* **Empty Commits/No Affects:** If `has_changes` evaluates to false, validation and build are entirely skipped for the run.
+* **Derived Products:** Because it relies on parsing the physical `include::../sles/...` tags, derived products like SLES for SAP and openSUSE Leap inherently rebuild if core SLES files are modified.
+* **Shared Notes:** The `adoc/shared.adoc` file will correctly map to any DC file whose dependency chain includes it.

--- a/scripts/detect-affected-dcs.py
+++ b/scripts/detect-affected-dcs.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+import os
+import sys
+import re
+
+def get_dc_main(dc_file):
+    """Extract MAIN file path from a DC file."""
+    try:
+        with open(dc_file, "r", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                if line.strip().startswith("MAIN="):
+                    # Extract the path, stripping quotes and spaces
+                    path = line.split("=", 1)[1].strip()
+                    path = re.sub(r"['\"]", "", path)
+                    return path
+    except Exception:
+        pass
+    return None
+
+def find_includes(file_path):
+    """Find all recursively included files inside an AsciiDoc file."""
+    includes = []
+    if not os.path.exists(file_path):
+        return includes
+    
+    dir_name = os.path.dirname(file_path)
+    try:
+        with open(file_path, "r", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                # Match line: include::some/path.adoc[...]
+                # Ignore lines that start with comment '//' or similar
+                clean_line = line.strip()
+                if clean_line.startswith("//"):
+                    continue
+                match = re.search(r"include::([^\[]+)\[", clean_line)
+                if match:
+                    inc_path = match.group(1).strip()
+                    # Resolve relative path
+                    resolved = os.path.normpath(os.path.join(dir_name, inc_path))
+                    includes.append(resolved)
+    except Exception:
+        pass
+    return includes
+
+def build_dependencies_for_dc(dc_file):
+    """Build set of all files a DC file depends on recursively."""
+    main_file = get_dc_main(dc_file)
+    if not main_file:
+        return set()
+    
+    dependencies = {dc_file, main_file}
+    
+    # Also add standard docinfo.xml if it exists
+    # e.g., adoc/sles/release-notes-sles-160.adoc -> adoc/sles/release-notes-sles-160-docinfo.xml
+    base_name, _ = os.path.splitext(main_file)
+    docinfo = f"{base_name}-docinfo.xml"
+    if os.path.exists(docinfo):
+        dependencies.add(docinfo)
+
+    # Recursively traverse includes
+    to_visit = [main_file]
+    visited = set()
+    while to_visit:
+        current = to_visit.pop(0)
+        if current in visited:
+            continue
+        visited.add(current)
+        
+        includes = find_includes(current)
+        for inc in includes:
+            dependencies.add(inc)
+            if inc not in visited:
+                to_visit.append(inc)
+                
+    return dependencies
+
+def main():
+    # 1. Gather all DC files in the root folder
+    dc_files = [f for f in os.listdir(".") if f.startswith("DC-") and os.path.isfile(f)]
+    
+    # 2. Build dependency map for each DC file
+    dc_deps = {}
+    for dc in dc_files:
+        dc_deps[dc] = build_dependencies_for_dc(dc)
+
+    # 3. Read changed files from stdin
+    changed_files = [line.strip() for line in sys.stdin if line.strip()]
+    if not changed_files:
+        # No changed files, output nothing
+        return
+
+    # 4. Check for "global" file changes that require building everything
+    global_triggers = False
+    for f in changed_files:
+        # If the file is not in adoc/ or a DC file itself, or is Makefile/scripts/workflow
+        if not f.startswith("adoc/") and not f.startswith("DC-"):
+            global_triggers = True
+            break
+        if f == "Makefile" or f.startswith(".github/") or f.startswith("scripts/"):
+            global_triggers = True
+            break
+
+    if global_triggers:
+        # Safety fallback: output all DC files
+        print(" ".join(sorted(dc_files)))
+        return
+
+    # 5. Map changed files to affected DC files
+    affected_dcs = set()
+    for changed in changed_files:
+        norm_changed = os.path.normpath(changed)
+        for dc, deps in dc_deps.items():
+            # Check if normalized changed file is in normalized deps
+            if any(os.path.normpath(dep) == norm_changed for dep in deps):
+                affected_dcs.add(dc)
+
+    if affected_dcs:
+        print(" ".join(sorted(affected_dcs)))
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_detect_affected_dcs.py
+++ b/scripts/test_detect_affected_dcs.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+import unittest
+import sys
+import os
+import subprocess
+
+class TestDependencyTracer(unittest.TestCase):
+    def test_script_exists(self):
+        self.assertTrue(os.path.exists("scripts/detect-affected-dcs.py"))
+
+    def test_global_fallback_makefile(self):
+        # Makefile edit must trigger all DC files
+        proc = subprocess.run(
+            [sys.executable, "scripts/detect-affected-dcs.py"],
+            input="Makefile\n",
+            capture_output=True,
+            text=True
+        )
+        output = proc.stdout.strip()
+        # Output must contain multiple DC files (e.g. SLES, SLED, etc.)
+        self.assertIn("DC-releasenotes_sles_16.0", output)
+        self.assertIn("DC-releasenotes_sles-sap_16.0", output)
+
+    def test_specific_sles_160_edit(self):
+        # Editing SLES 16.0 master .adoc should trigger sles_16.0
+        proc = subprocess.run(
+            [sys.executable, "scripts/detect-affected-dcs.py"],
+            input="adoc/sles/release-notes-sles-160.adoc\n",
+            capture_output=True,
+            text=True
+        )
+        output = proc.stdout.strip().split()
+        self.assertIn("DC-releasenotes_sles_16.0", output)
+
+    def test_recursive_sles_160_includes(self):
+        # SLES 16.0 includes version160.adoc. Let's test that editing version160.adoc triggers sles_16.0 and sles-sap_16.0 (due to SLES-SAP includes)
+        proc = subprocess.run(
+            [sys.executable, "scripts/detect-affected-dcs.py"],
+            input="adoc/sles/version160.adoc\n",
+            capture_output=True,
+            text=True
+        )
+        output = proc.stdout.strip().split()
+        self.assertIn("DC-releasenotes_sles_16.0", output)
+        self.assertIn("DC-releasenotes_sles-sap_16.0", output)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR introduces an automated dependency tracer for our AsciiDoc/DocBook release notes to dynamically identify affected DC files on push/PR, combined with GHA caching of the DAPS build directory.

### Key Changes:
- **Dependency Tracer (`scripts/detect-affected-dcs.py`):** Recursively parses `include::` lines in AsciiDoc files to map any modified source file to its parent `DC-*` targets. Correctly handles derived products like SLES for SAP and openSUSE Leap out of the box because of physical include-tracing. Fallbacks to building all products if global files (Makefile, scripts, workflows) are changed.
- **Unit Tests (`scripts/test_detect_affected_dcs.py`):** Verification tests for recursive includes and fallback behaviors.
- **GitHub Actions Workflow (`.github/workflows/asciidoc.yml`):** Runs the detector, compiles/validates only affected files, and caches the DAPS `build/` directory for fast incremental compilation.