### PR TITLE
SLES 16.1: Document Secure Boot support for ECKD DASD disks on IBM Z (jsc#PED-15030)

### DIFF
--- a/.github/workflows/asciidoc.yml
+++ b/.github/workflows/asciidoc.yml
@@ -38,7 +38,7 @@ jobs:
           else
             BASE_SHA="${{ github.event.before }}"
             HEAD_SHA="${{ github.event.after }}"
-            if [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ] || [ -z "$BASE_SHA" ]; then
+            if [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ] || [ -z "$BASE_SHA" ] || ! git rev-parse --quiet --verify "$BASE_SHA" >/dev/null 2>&1; then
               BASE_SHA="HEAD^"
             fi
           fi

--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -15,6 +15,9 @@
     <revdescription>
      <itemizedlist>
       <listitem>
+       <para>Documented Secure Boot support for ECKD DASD disks on IBM Z (<link xlink:href="index.html#jsc-PED-15030">jsc#PED-15030</link>)</para>
+      </listitem>
+      <listitem>
        <para>Documented removed support for IBM 3480 and 3590 tape drives on IBM Z (<link xlink:href="index.html#bsc-1266763">bsc#1266763</link>)</para>
       </listitem>
       <listitem>

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -414,6 +414,16 @@ include::../kernel-161-aarch64.adoc[leveloffset=+2]
 Information in this section applies to {z-productname}.
 For more information, see https://www.ibm.com/docs/en/linux-on-systems?topic=distributions-suse-linux-enterprise-server
 
+// jsc#PED-13734
+// bsc#1249961
+[#jsc-PED-15030]
+=== Secure Boot support for ECKD DASD disks on {ibmz}
+
+{productname} now supports and automatically proposes Secure Boot during installation for ECKD DASD disks.
+This support is available on IBM z16, LinuxONE 4, or newer systems.
+The bootloader installer (`zipl`) automatically writes both secure boot (list-directed IPL) and non-secure boot (CCW) boot records.
+This ensures that the installed system remains bootable on older systems that do not support Secure Boot.
+
 // jsc#PED-14585
 // jsc#DOCTEAM-2356
 [#bsc-1266763]


### PR DESCRIPTION
This PR creates a release note for the new Secure Boot support on s390x ECKD DASD disks in SLES 16.1, as requested by [PED-15030](https://jira.suse.com/browse/PED-15030).