### PR TITLE
Fix text target by updating path and file names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,8 @@ text_params    :=
 
 # files to be created:
 profile_result       := build/.profiled/noprofile/release-notes-$(PRODUCT_VERSION).xml
-text_result          := build/release-notes-$(PRODUCT_VERSION)/release-notes-$(PRODUCT_VERSION).txt
-yast_html_result_dir := build/release-notes-$(PRODUCT_VERSION)/yast-html
+text_result          := build/releasenotes_$(PRODUCT_VERSION)/releasenotes_$(PRODUCT_VERSION).txt
+yast_html_result_dir := build/releasenotes_$(PRODUCT_VERSION)/yast-html
 yast_html_result     := $(yast_html_result_dir)/release-notes.html
 
 


### PR DESCRIPTION
Avoid `make text PRODUCT_VERSION=sles_16.1` failing by updating the build directory name from `release-notes-` to `releasenotes_`, and same for the `$text_result` filename.

Fixes #96.