### PR TITLE
SLES 16.1, SLES for SAP 16.1: Document availability of RMT server (jsc#PED-14922)

### DIFF
--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -15,6 +15,9 @@
     <revdescription>
      <itemizedlist>
       <listitem>
+       <para>Documented availability of Repository Mirroring Tool (RMT) server (<link xlink:href="index.html#jsc-PED-14922">jsc#PED-14922</link>)</para>
+      </listitem>
+      <listitem>
        <para>Documented Secure Boot support for ECKD DASD disks on IBM Z (<link xlink:href="index.html#jsc-PED-15030">jsc#PED-15030</link>)</para>
       </listitem>
       <listitem>

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -168,6 +168,13 @@ See <<jsc-PED-16106>>.
 // jsc#PED-12658
 * `rasdaemon` has been updated to version 0.8.4. This version supports machine checks related to CXL memory. Since Intel® Optane™ Memory products have reached End of Life (EOL), {productname} {this-version} does not support them either.
 
+[#jsc-PED-14922]
+=== Repository Mirroring Tool (RMT) server now available
+
+{productname} {this-version} includes the Repository Mirroring Tool (RMT) server.
+RMT allows mirroring of SUSE repositories and client registration inside a private network.
+RMT has been updated to version 3, which is compatible with Ruby 3, ensuring long-term support.
+
 // jsc#PED-4973
 include::../shared.adoc[tags=jscped-4973,leveloffset=+2]
 


### PR DESCRIPTION
This PR documents the availability of the Repository Mirroring Tool (RMT) server in SLES 16.1 (and SLES for SAP 16.1).