### PR TITLE
SLES 16.0: Add note about GNOME Software online update (jsc#PED-15411)

### DIFF
--- a/adoc/sles/release-notes-sles-160-docinfo.xml
+++ b/adoc/sles/release-notes-sles-160-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xml:id="revhistory" xmlns:xlink="http://www.w3.org/1999/xlink">
     <revision>
+     <date>2026-07-28</date>
+     <revdescription>
+      <itemizedlist>
+       <listitem>
+        <para>Added GNOME Software online update support and transactional systems detection (<link xlink:href="index.html#jsc-PED-15411">jsc#PED-15411</link>)</para>
+       </listitem>
+      </itemizedlist>
+     </revdescription>
+    </revision>
+    <revision>
      <date>2026-07-27</date>
      <revdescription>
       <itemizedlist>

--- a/adoc/sles/release-notes-sles-160.adoc
+++ b/adoc/sles/release-notes-sles-160.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version160.adoc[]
 
 = SUSE Linux Enterprise Server Release Notes
-:revdate: 2026-07-27
+:revdate: 2026-07-28
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/sles/version160.adoc
+++ b/adoc/sles/version160.adoc
@@ -180,6 +180,18 @@ See <<jsc-PED-6311>>.
 // jsc#PED-11656
 * We now provide a unified image that can be used to install either {slesa} or {slessapa}
 
+[#jsc-PED-15411]
+=== GNOME Software is now available and supports online updates
+
+GNOME Software (`gnome-software`) is now shipped as part of the software stack in {productname} {this-version}.
+It has been modified to support online updates, allowing the majority of packages to be updated without requiring a reboot.
+Reboots are still required for critical updates such as kernel, firmware, or driver updates.
+
+On transactional (immutable) systems, the PackageKit plugin of GNOME Software automatically detects the environment and disables itself.
+This prevents failed update operations on the read-only root file system.
+On transactional systems, GNOME Software can still manage Flatpak applications, while system packages must be managed using the `transactional-update` tool.
+
+
 [#jsc-PED-15471]
 === Node.js 24 is now the default version
 


### PR DESCRIPTION
This release note documents GNOME Software shipping with online update capability on SLES 16.0 and the behavior on transactional/immutable systems (jsc#PED-15411).