### PR TITLE
SLES 15 SP5, 15 SP6: Deprecate and remove libgrss package (jsc#PED-2431)

### DIFF
--- a/adoc/sles/15sp5/changelog.adoc
+++ b/adoc/sles/15sp5/changelog.adoc
@@ -8,6 +8,13 @@ include::attributes-product.adoc[]
 [#changelog]
 == Changelog for {this-version}
 
+[#release-2026-07-29]
+=== 2026-07-29
+
+==== New
+
+* Added deprecation note for `libgrss` to <<removed-deprecated>> ({jira-url}PED-2431[Jira])
+
 [#release-2025-10-31]
 === 2025-10-31
 

--- a/adoc/sles/15sp5/release-notes.adoc
+++ b/adoc/sles/15sp5/release-notes.adoc
@@ -3,7 +3,7 @@ include::attributes-product.adoc[]
 
 [#rnotes]
 = {rnotes}
-:revdate: 2025-11-12
+:revdate: 2026-07-29
 :page-revdate: {revdate}
 
 include::abstract.adoc[]

--- a/adoc/sles/15sp5/removed-deprecated.adoc
+++ b/adoc/sles/15sp5/removed-deprecated.adoc
@@ -60,7 +60,6 @@ The following features and packages are deprecated and will be removed in a futu
 // jsc#PED-2431
 // bsc#1186594
 * `libgrss` has been deprecated and will be removed in {productnameshort} 15 SP6.
-
 // jsc#PED-4018
 * `docker-runc` has been deprecated and will be removed in {productnameshort} 15 SP6. Use `runc` instead.
 // jsc#PED-8166

--- a/adoc/sles/15sp5/removed-deprecated.adoc
+++ b/adoc/sles/15sp5/removed-deprecated.adoc
@@ -57,6 +57,10 @@ Also see the following notes elsewhere:
 
 The following features and packages are deprecated and will be removed in a future version of {productname}.
 
+// jsc#PED-2431
+// bsc#1186594
+* `libgrss` has been deprecated and will be removed in {productnameshort} 15 SP6.
+
 // jsc#PED-4018
 * `docker-runc` has been deprecated and will be removed in {productnameshort} 15 SP6. Use `runc` instead.
 // jsc#PED-8166

--- a/adoc/sles/15sp6/changelog.adoc
+++ b/adoc/sles/15sp6/changelog.adoc
@@ -8,6 +8,13 @@ include::attributes-product.adoc[]
 [#changelog]
 == Changelog for {this-version}
 
+[#release-2026-07-29]
+=== 2026-07-29
+
+==== New
+
+* Added note about removal of `libgrss` to <<removed-deprecated>> ({jira-url}PED-2431[Jira])
+
 [#release-2025-10-31]
 === 2025-10-31
 

--- a/adoc/sles/15sp6/release-notes.adoc
+++ b/adoc/sles/15sp6/release-notes.adoc
@@ -3,7 +3,7 @@ include::attributes-product.adoc[]
 
 [#rnotes]
 = {rnotes}
-:revdate: 2025-11-12
+:revdate: 2026-07-29
 :page-revdate: {revdate}
 
 include::abstract.adoc[]

--- a/adoc/sles/15sp6/removed-deprecated.adoc
+++ b/adoc/sles/15sp6/removed-deprecated.adoc
@@ -36,7 +36,6 @@ For more information, see <<jsc-SLE-0000>>.
 // jsc#PED-2431
 // bsc#1186594
 * `libgrss` has been removed.
-
 // jsc#PED-4018
 * `docker-runc` has been remove. Use `runc` instead.
 // jsc#PED-8162

--- a/adoc/sles/15sp6/removed-deprecated.adoc
+++ b/adoc/sles/15sp6/removed-deprecated.adoc
@@ -33,6 +33,10 @@ Use Replacement Feature instead.
 For more information, see <<jsc-SLE-0000>>.
 ////
 
+// jsc#PED-2431
+// bsc#1186594
+* `libgrss` has been removed.
+
 // jsc#PED-4018
 * `docker-runc` has been remove. Use `runc` instead.
 // jsc#PED-8162


### PR DESCRIPTION
Addresses:
- Jira: https://jira.suse.com/browse/PED-2431
- Bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1186594