### PR TITLE
SLES 16.0: Update tracking references for NIS removal (jsc#PED-3865)

### DIFF
--- a/adoc/sles/release-notes-sles-160-docinfo.xml
+++ b/adoc/sles/release-notes-sles-160-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xml:id="revhistory" xmlns:xlink="http://www.w3.org/1999/xlink">
     <revision>
+     <date>2026-07-29</date>
+     <revdescription>
+      <itemizedlist>
+       <listitem>
+        <para>Updated tracking reference for NIS removal note (<link xlink:href="index.html#removed">jsc#PED-3865</link>)</para>
+       </listitem>
+      </itemizedlist>
+     </revdescription>
+    </revision>
+    <revision>
      <date>2026-07-28</date>
      <revdescription>
       <itemizedlist>
@@ -208,6 +218,16 @@
     <itemizedlist>
      <listitem>
       <para>Add GFS2 to <link xlink:href="index.html#file-system-comparison">file system comparison table</link> (<link xlink:href="https://bugzilla.suse.com/show_bug.cgi?id=1257500">bsc#1257500</link>)</para>
+     </listitem>
+    </itemizedlist>
+   </revdescription>
+  </revision>
+  <revision>
+   <date>2025-11-13</date>
+   <revdescription>
+    <itemizedlist>
+     <listitem>
+      <para>Added note about NIS removal (<link xlink:href="index.html#removed">bsc#1253376</link>, <link xlink:href="index.html#removed">jsc#PED-3865</link>)</para>
      </listitem>
     </itemizedlist>
    </revdescription>

--- a/adoc/sles/release-notes-sles-160.adoc
+++ b/adoc/sles/release-notes-sles-160.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version160.adoc[]
 
 = SUSE Linux Enterprise Server Release Notes
-:revdate: 2026-07-28
+:revdate: 2026-07-29
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/sles/version160.adoc
+++ b/adoc/sles/version160.adoc
@@ -1307,6 +1307,7 @@ It was added by accident to {productname} 16.0 and is unsupported.
 // bsc#1254327
 * The filesystem based HA solution for ENSA1/2 central services is not supported. See https://www.suse.com/releasenotes/x86_64/SLE-SAP/15-SP7/index.html#jsc-PED-11566 for more information.
 // jsc#SLE-24335
+// jsc#PED-3865
 // bsc#1253376
 * NIS has been removed.
 This includes packages implementing NIS like `ypserv`, NIS code in {suse} tools, and all NIS client code.


### PR DESCRIPTION
Adds jsc#PED-3865 and bsc#1253376 tracking references to SLES 16.0 NIS removal note.