### PR TITLE
SLES for SAP 16.0, SLES for SAP 16.1: Add note about unsupported HA solution for NetWeaver central services (bsc#1274569)

### DIFF
--- a/adoc/slesap/release-notes-slesap-160-docinfo.xml
+++ b/adoc/slesap/release-notes-slesap-160-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xml:id="revhistory" xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-08-10</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Added note about unsupported HA solution for NetWeaver central services (<link xlink:href="index.html#bsc-1274569">bsc#1274569</link>)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-06-30</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/slesap/release-notes-slesap-160.adoc
+++ b/adoc/slesap/release-notes-slesap-160.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version160.adoc[]
 
 = {productname} Release Notes
-:revdate: 2026-06-30
+:revdate: 2026-08-10
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/slesap/release-notes-slesap-161-docinfo.xml
+++ b/adoc/slesap/release-notes-slesap-161-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xml:id="revhistory" xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-08-10</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Added note about unsupported HA solution for NetWeaver central services (<link xlink:href="index.html#bsc-1274569">bsc#1274569</link>)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-07-28</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/slesap/release-notes-slesap-161.adoc
+++ b/adoc/slesap/release-notes-slesap-161.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version161.adoc[]
 
 = {productname} Release Notes
-:revdate: 2026-07-28
+:revdate: 2026-08-10
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/slesap/version160.adoc
+++ b/adoc/slesap/version160.adoc
@@ -56,6 +56,12 @@ The following features and packages have been removed in this release.
 
 * `SAPHanaSR` and `SAPHanaSR-scaleout` have been removed. Use `SAPHanaSR-angi` instead.
 
+// jsc#PED-11566
+// bsc#1274569
+[#bsc-1274569]
+* The HA solution for NetWeaver central services is not supported.
+See https://documentation.suse.com/releasenotes/sles-sap/15-SP7/index.html#jsc-PED-11566 for more information. (bsc#1274569)
+
 // [#deprecated]
 // === Deprecated features and packages
 

--- a/adoc/slesap/version161.adoc
+++ b/adoc/slesap/version161.adoc
@@ -56,6 +56,12 @@ The following features and packages have been removed in this release.
 
 * `SAPHanaSR` and `SAPHanaSR-scaleout` have been removed. Use `SAPHanaSR-angi` instead.
 
+// jsc#PED-11566
+// bsc#1274569
+[#bsc-1274569]
+* The HA solution for NetWeaver central services is not supported.
+See https://documentation.suse.com/releasenotes/sles-sap/15-SP7/index.html#jsc-PED-11566 for more information. (bsc#1274569)
+
 // [#deprecated]
 // === Deprecated features and packages
 


### PR DESCRIPTION
Adds the missing NetWeaver HA unsupported notice to SLES for SAP 16.0 and 16.1 version files, bumps revdate, and updates docinfo revision history blocks.