### PR TITLE
SLES 16.1: Add note about kdump capture failure on NVMe-oF targets (bsc#1272626)

### DIFF
--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -17,6 +17,9 @@
       <listitem>
        <para>Added section <link xlink:href="index.html#bsc-1249569">Login times out on HMC virtual terminal</link> (bsc#1249569)</para>
       </listitem>
+      <listitem>
+       <para>Added section <link xlink:href="index.html#bsc-1272626">Kdump capture fails on NVMe-oF targets</link> (bsc#1272626)</para>
+      </listitem>
      </itemizedlist>
     </revdescription>
   </revision>

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -486,6 +486,13 @@ include::../shared.adoc[tag=jscped-15968,leveloffset=+2]
 
 Information in this section applies to {power-productname}.
 
+[#bsc-1272626]
+=== Kdump capture fails on NVMe-oF targets
+
+During kdump execution, attempting to capture a dump file to an NVMe over Fibre Channel (NVMe-FC) target on a Horton adapter fails.
+This issue occurs because the NVMe-FC driver maps numerous buffers for DMA, but not enough Translation Control Entries (TCEs) are freed from the Dynamic DMA Window (DDW) at kdump time.
+As a workaround, use Firmware-Assisted Dump (FADUMP), which is unaffected by this limitation.
+
 [#bsc-1249569]
 === Login times out on HMC virtual terminal
 


### PR DESCRIPTION
This pull request adds a release note for Bugzilla bug 1272626 describing kdump capture failure on NVMe-oF (NVMe-FC) targets on POWER11 platforms.