### PR TITLE
SLES 16.1, SLES for SAP 16.1, openSUSE Leap 16.1: Document removal of ceph and thrift packages from Package Hub (jsc#PED-16797)

### DIFF
--- a/adoc/leap/release-notes-leap-161-docinfo.xml
+++ b/adoc/leap/release-notes-leap-161-docinfo.xml
@@ -12,6 +12,16 @@
 <date>{revdate}</date>
 <revhistory xml:id="revhistory" xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-08-11</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Documented removal of ceph and thrift packages from SUSE Package Hub (<link xlink:href="index.html#removed">jsc#PED-16797</link>)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-06-09</date>
     <revdescription>
       <itemizedlist>

--- a/adoc/leap/release-notes-leap-161.adoc
+++ b/adoc/leap/release-notes-leap-161.adoc
@@ -5,7 +5,7 @@ include::attributes.adoc[]
 :major-version: 16
 
 = openSUSE Leap Release Notes
-:revdate: 2026-05-25
+:revdate: 2026-08-11
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level features, capabilities, limitations, and important updates in {productname}. {productname} {this-version} is built on top of binary RPM packages from SUSE Linux Enterprise, providing a stable enterprise-grade core while adding unique community-driven enhancements.

--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-08-11</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Documented removal of ceph and thrift packages from SUSE Package Hub (<link xlink:href="index.html#removed">jsc#PED-16797</link>)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-08-10</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/sles/release-notes-sles-161.adoc
+++ b/adoc/sles/release-notes-sles-161.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version161.adoc[]
 
 = SUSE Linux Enterprise Server Release Notes
-:revdate: 2026-08-10
+:revdate: 2026-08-11
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -612,6 +612,9 @@ This section lists features and packages that were removed from {productname} or
 
 The following features and packages have been removed in this release.
 
+// jsc#PED-16797
+* Due to being no longer maintained, the `ceph` and `thrift` packages have been removed from {ph}.
+
 // jsc#PED-14453
 * The legacy `SDL2` package has been removed in favor of `sdl2-compat` and the newer `SDL3` package.
   Applications relying on SDL 2.0 now utilize the `sdl2-compat` compatibility layer.

--- a/adoc/slesap/release-notes-slesap-161-docinfo.xml
+++ b/adoc/slesap/release-notes-slesap-161-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xml:id="revhistory" xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-08-11</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Documented removal of ceph and thrift packages from SUSE Package Hub (<link xlink:href="index.html#removed">jsc#PED-16797</link>)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-08-10</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/slesap/release-notes-slesap-161.adoc
+++ b/adoc/slesap/release-notes-slesap-161.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version161.adoc[]
 
 = {productname} Release Notes
-:revdate: 2026-08-10
+:revdate: 2026-08-11
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.


### PR DESCRIPTION
This PR documents the removal of `ceph` and `thrift` packages from SUSE Package Hub due to being no longer maintained.

The release notes have been added to SLES 16.1 core (`version161.adoc`), and are automatically inherited by SLES for SAP 16.1 and openSUSE Leap 16.1. The master file revision dates and the changelogs (`docinfo.xml`) for all three products have been updated accordingly.

Jira issue: [PED-16797](https://jira.suse.com/browse/PED-16797)