### PR TITLE
SLES, SLES for SAP, SLE HA 16.1: Document NVIDIA KMPs RT kernel limitation (jsc#PED-16382)

### DIFF
--- a/adoc/shared.adoc
+++ b/adoc/shared.adoc
@@ -334,3 +334,13 @@ By default, system-wide cryptographic policies now enable post-quantum cryptogra
 This prevents connection warnings (such as `WARNING: connection is not using a post-quantum key exchange algorithm`) from modern external SSH clients that require post-quantum security by default.
 This support is provided by re-enabling the X25519 key exchange group in the default system-wide cryptographic policy, which allows secure post-quantum key exchange combinations such as `mlkem768x25519-sha256` and `sntrup761x25519-sha512` to be negotiated.
 end::jscped-15713[]
+
+tag::jscped-16382[]
+[#jsc-PED-16382]
+= {nvidia} drivers not available for real-time kernel
+
+With the introduction of the real-time kernel in {productname} {this-version}, some third-party kernel modules are not compatible.
+The {nvidia} drivers are only built for the default kernel.
+Consequently, {nvidia} drivers are not available when running the real-time kernel.
+end::jscped-16382[]
+

--- a/adoc/sleha/release-notes-sleha-161-docinfo.xml
+++ b/adoc/sleha/release-notes-sleha-161-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xml:id="revhistory" xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-08-17</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Documented that NVIDIA KMPs are not available for the real-time kernel (<link xlink:href="index.html#jsc-PED-16382">jsc#PED-16382</link>)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-07-21</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/sleha/release-notes-sleha-161.adoc
+++ b/adoc/sleha/release-notes-sleha-161.adoc
@@ -2,7 +2,7 @@ include::../common/attributes-generic.adoc[]
 include::attributes.adoc[]
 
 = {productname} Release Notes
-:revdate: 2026-07-21
+:revdate: 2026-08-17
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/sleha/version161.adoc
+++ b/adoc/sleha/version161.adoc
@@ -27,6 +27,9 @@ Installation media, VM images and public cloud images are usually refreshed ever
 // jsc#PED-14688
 include::../shared.adoc[tags=jscped-14688,leveloffset=+3]
 
+// jsc#PED-16382
+include::../shared.adoc[tags=jscped-16382,leveloffset=+3]
+
 ==== `csync2` requires separate initialization
 
 Previously, csync2 was configured automatically during initial cluster bootstrap.

--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-08-17</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Documented that NVIDIA KMPs are not available for the real-time kernel (<link xlink:href="index.html#jsc-PED-16382">jsc#PED-16382</link>)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-08-11</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/sles/release-notes-sles-161.adoc
+++ b/adoc/sles/release-notes-sles-161.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version161.adoc[]
 
 = SUSE Linux Enterprise Server Release Notes
-:revdate: 2026-08-11
+:revdate: 2026-08-17
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -174,6 +174,9 @@ See <<jsc-PED-16106>>.
 // jsc#PED-12658
 * `rasdaemon` has been updated to version 0.8.4. This version supports machine checks related to CXL memory. Since Intel® Optane™ Memory products have reached End of Life (EOL), {productname} {this-version} does not support them either.
 
+// jsc#PED-16382
+include::../shared.adoc[tags=jscped-16382,leveloffset=+2]
+
 [#jsc-PED-14922]
 === Repository Mirroring Tool (RMT) server now available
 

--- a/adoc/slesap/release-notes-slesap-161-docinfo.xml
+++ b/adoc/slesap/release-notes-slesap-161-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xml:id="revhistory" xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-08-17</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Documented that NVIDIA KMPs are not available for the real-time kernel (<link xlink:href="index.html#jsc-PED-16382">jsc#PED-16382</link>)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-08-11</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/slesap/release-notes-slesap-161.adoc
+++ b/adoc/slesap/release-notes-slesap-161.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version161.adoc[]
 
 = {productname} Release Notes
-:revdate: 2026-08-11
+:revdate: 2026-08-17
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.


### PR DESCRIPTION
Documents the limitation that NVIDIA GPU driver Kernel Module Packages (KMPs) are not available/supported on the real-time kernel (`kernel-rt`) in SLES, SLES for SAP, and SLE HA 16.1.

Jira: https://jira.suse.com/browse/PED-16382