### PR TITLE
SLES 16.1: Add note about Distrobox replacing Toolbox (jsc#PED-16282)

### DIFF
--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -17,6 +17,9 @@
       <listitem>
        <para>Documented that NVIDIA KMPs are not available for the real-time kernel (<link xlink:href="index.html#jsc-PED-16382">jsc#PED-16382</link>)</para>
       </listitem>
+      <listitem>
+       <para>Documented that distrobox is now pre-installed by default, replacing toolbox (<link xlink:href="index.html#jsc-PED-16282">jsc#PED-16282</link>)</para>
+      </listitem>
      </itemizedlist>
     </revdescription>
   </revision>

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -174,6 +174,14 @@ See <<jsc-PED-16106>>.
 // jsc#PED-12658
 * `rasdaemon` has been updated to version 0.8.4. This version supports machine checks related to CXL memory. Since Intel® Optane™ Memory products have reached End of Life (EOL), {productname} {this-version} does not support them either.
 
+[#jsc-PED-16282]
+=== Distrobox pre-installed by default
+
+{productname} now includes `distrobox` pre-installed by default, replacing the older `toolbox` utility.
+`distrobox` enables launching mutable, persistent containerized environments utilizing `podman` or `docker`.
+These environments are tightly integrated with the host system, sharing access to the home directory, external storage devices, audio and video streams, and graphical servers.
+This integration allows running and debugging tools from any Linux distribution directly within the terminal without modifying the underlying operating system.
+
 // jsc#PED-16382
 include::../shared.adoc[tags=jscped-16382,leveloffset=+2]
 


### PR DESCRIPTION
Implements release notes for PED-16282 / jsc#PED-16282.