### PR TITLE
SLES 16.1: Add note about unified systemd service presets (jsc#PED-16083)

### DIFF
--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -15,6 +15,9 @@
     <revdescription>
      <itemizedlist>
       <listitem>
+       <para>Added section <link xlink:href="index.html#jsc-PED-16083">Unified systemd service presets between standard and immutable modes</link> (jsc#PED-16083)</para>
+      </listitem>
+      <listitem>
        <para>Documented that NVIDIA KMPs are not available for the real-time kernel (<link xlink:href="index.html#jsc-PED-16382">jsc#PED-16382</link>)</para>
       </listitem>
       <listitem>

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -174,6 +174,14 @@ See <<jsc-PED-16106>>.
 // jsc#PED-12658
 * `rasdaemon` has been updated to version 0.8.4. This version supports machine checks related to CXL memory. Since Intel® Optane™ Memory products have reached End of Life (EOL), {productname} {this-version} does not support them either.
 
+[#jsc-PED-16083]
+=== Unified systemd service presets between standard and immutable modes
+
+To provide a consistent administration experience, systemd service presets have been unified between standard and immutable installation modes.
+As part of this unification, several standard service presets have been newly enabled by default on standard installations, including the `cloud-init` stack, `container-image-prune.timer`, `kubelet.service`, and others.
+Similarly, standard service presets such as `firewalld.service`, `chronyd.service`, `gdm.service`, and virtualization helpers have been enabled by default on immutable installations.
+Only specific presets directly related to transactional system management (such as `transactional-update.timer` and `health-checker.service`) remain restricted to their respective modes.
+
 [#jsc-PED-16282]
 === Distrobox pre-installed by default
 


### PR DESCRIPTION
This PR adds the release note documenting the unification of systemd service presets between standard and immutable modes in SLES 16.1.