### PR TITLE
SLE HA 16.1, SLES for SAP 16.1: Deprecate stonith and orphan terminology in Pacemaker (jsc#PED-15950)

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -83,12 +83,11 @@ make serve
 
 `adoc/shared.adoc` holds notes shared across versions using AsciiDoc tags.
 
-**CRITICAL RULE — INLINE VS SHARED:** Only place notes in `adoc/shared.adoc` if they are shared across *independent parallel tracks* within the 16.x line (such as **SLE HA 16.x** and **SLES for SAP 16.x**), or across different minor releases (such as **16.0** and **16.1**).
+**CRITICAL RULE — INLINE VS SHARED:** Only place notes in `adoc/shared.adoc` if they are shared across *independent codebases or different major version streams* (for example, a note that applies to SLES 15 SP6 AND SLES 16.0).
 
-* **Codestream 15 Active Ban:** Although `15spX` directories exist in this repository, they are frozen. **NEVER** edit 15.x files or attempt to share notes with them in this repository. All active 15.x updates must be done independently in their legacy `release-notes-*` repositories.
-* **SLES Core vs. Derived Products:** Standard SLES Core notes that only apply to SLES and its derived products (like openSUSE Leap 16.1 or SLES for SAP 16.1) should **NEVER** use `shared.adoc`.
-* **Why?** Derived products natively inherit the SLES core release notes (such as `adoc/sles/version161.adoc`) directly. Placing the note inline in the SLES core spec file automatically shares it with all derived products.
-* **Parallel Extension Tracks (The HA Exception):** Since **SLE HA** and **SLES Core** are independent tracks, SLES for SAP does *not* automatically inherit SLE HA release notes (even though SLES for SAP includes HA packages). For HA-specific notes that must appear in both SLE HA 16.x and SLES for SAP 16.x, using `shared.adoc` with tags is the preferred way to avoid source code duplication.
+* **NEVER use `shared.adoc` for notes specific to a single core baseline (e.g., SLES 16.1 only)**, even if the change applies to multiple derived products (like openSUSE Leap 16.1 or SLES for SAP 16.1).
+* **Why?** Derived products inherit the SLES core release notes (such as `adoc/sles/version161.adoc`) directly. Placing the note inline in the SLES spec file automatically shares it with all derived products without needing any `shared.adoc` tags.
+* If a note is specific to a single core/version, always write it as an inline note directly within that core's spec file.
 
 ```asciidoc
 tag::TAGNAME[]

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -83,11 +83,12 @@ make serve
 
 `adoc/shared.adoc` holds notes shared across versions using AsciiDoc tags.
 
-**CRITICAL RULE — INLINE VS SHARED:** Only place notes in `adoc/shared.adoc` if they are shared across *independent codebases or different major version streams* (for example, a note that applies to SLES 15 SP6 AND SLES 16.0).
+**CRITICAL RULE — INLINE VS SHARED:** Only place notes in `adoc/shared.adoc` if they are shared across *independent parallel tracks* within the 16.x line (such as **SLE HA 16.x** and **SLES for SAP 16.x**), or across different minor releases (such as **16.0** and **16.1**).
 
-* **NEVER use `shared.adoc` for notes specific to a single core baseline (e.g., SLES 16.1 only)**, even if the change applies to multiple derived products (like openSUSE Leap 16.1 or SLES for SAP 16.1).
-* **Why?** Derived products inherit the SLES core release notes (such as `adoc/sles/version161.adoc`) directly. Placing the note inline in the SLES spec file automatically shares it with all derived products without needing any `shared.adoc` tags.
-* If a note is specific to a single core/version, always write it as an inline note directly within that core's spec file.
+* **Codestream 15 Active Ban:** Although `15spX` directories exist in this repository, they are frozen. **NEVER** edit 15.x files or attempt to share notes with them in this repository. All active 15.x updates must be done independently in their legacy `release-notes-*` repositories.
+* **SLES Core vs. Derived Products:** Standard SLES Core notes that only apply to SLES and its derived products (like openSUSE Leap 16.1 or SLES for SAP 16.1) should **NEVER** use `shared.adoc`.
+* **Why?** Derived products natively inherit the SLES core release notes (such as `adoc/sles/version161.adoc`) directly. Placing the note inline in the SLES core spec file automatically shares it with all derived products.
+* **Parallel Extension Tracks (The HA Exception):** Since **SLE HA** and **SLES Core** are independent tracks, SLES for SAP does *not* automatically inherit SLE HA release notes (even though SLES for SAP includes HA packages). For HA-specific notes that must appear in both SLE HA 16.x and SLES for SAP 16.x, using `shared.adoc` with tags is the preferred way to avoid source code duplication.
 
 ```asciidoc
 tag::TAGNAME[]

--- a/adoc/shared.adoc
+++ b/adoc/shared.adoc
@@ -344,3 +344,20 @@ The {nvidia} drivers are only built for the default kernel.
 Consequently, {nvidia} drivers are not available when running the real-time kernel.
 end::jscped-16382[]
 
+tag::jscped-15950[]
+[#jsc-PED-15950]
+= Pacemaker "stonith" and "orphan" terminology deprecated
+
+The terms `stonith` and `orphan` have been deprecated in Pacemaker in favor of `fencing` and `removed`.
+The old configuration properties are still supported but are marked as deprecated, and their corresponding new names should be used instead:
+
+* `stonith-enabled` is now `fencing-enabled`
+* `stonith-action` is now `fencing-action`
+* `stonith-max-attempts` is now `fencing-max-attempts`
+* `stonith-timeout` is now `fencing-timeout`
+* `stonith-watchdog-timeout` is now `fencing-watchdog-timeout`
+* `fence-reaction` is now `fencing-reaction`
+* `stop-orphan-resources` is now `stop-removed-resources`
+* `stop-orphan-actions` is now `cancel-removed-actions`
+end::jscped-15950[]
+

--- a/adoc/sleha/release-notes-sleha-161-docinfo.xml
+++ b/adoc/sleha/release-notes-sleha-161-docinfo.xml
@@ -18,7 +18,7 @@
        <para>Documented that NVIDIA KMPs are not available for the real-time kernel (<link xlink:href="index.html#jsc-PED-16382">jsc#PED-16382</link>)</para>
       </listitem>
       <listitem>
-       <para>Documented the deprecation of stonith and orphan terminology in Pacemaker (<link xlink:href="index.html#removed-deprecated">jsc#PED-15950</link>)</para>
+       <para>Documented the deprecation of stonith and orphan terminology in Pacemaker (<link xlink:href="index.html#jsc-PED-15950">jsc#PED-15950</link>)</para>
       </listitem>
      </itemizedlist>
     </revdescription>

--- a/adoc/sleha/release-notes-sleha-161-docinfo.xml
+++ b/adoc/sleha/release-notes-sleha-161-docinfo.xml
@@ -18,7 +18,7 @@
        <para>Documented that NVIDIA KMPs are not available for the real-time kernel (<link xlink:href="index.html#jsc-PED-16382">jsc#PED-16382</link>)</para>
       </listitem>
       <listitem>
-       <para>Documented the <link xlink:href="index.html#jsc-PED-15950">deprecation of stonith and orphan terminology in Pacemaker</link></para>
+       <para>Documented the deprecation of stonith and orphan terminology in Pacemaker (<link xlink:href="index.html#jsc-PED-15950">jsc#PED-15950</link>)</para>
       </listitem>
      </itemizedlist>
     </revdescription>

--- a/adoc/sleha/release-notes-sleha-161-docinfo.xml
+++ b/adoc/sleha/release-notes-sleha-161-docinfo.xml
@@ -17,6 +17,9 @@
       <listitem>
        <para>Documented that NVIDIA KMPs are not available for the real-time kernel (<link xlink:href="index.html#jsc-PED-16382">jsc#PED-16382</link>)</para>
       </listitem>
+      <listitem>
+       <para>Documented the deprecation of stonith and orphan terminology in Pacemaker (<link xlink:href="index.html#removed-deprecated">jsc#PED-15950</link>)</para>
+      </listitem>
      </itemizedlist>
     </revdescription>
   </revision>

--- a/adoc/sleha/release-notes-sleha-161-docinfo.xml
+++ b/adoc/sleha/release-notes-sleha-161-docinfo.xml
@@ -18,7 +18,7 @@
        <para>Documented that NVIDIA KMPs are not available for the real-time kernel (<link xlink:href="index.html#jsc-PED-16382">jsc#PED-16382</link>)</para>
       </listitem>
       <listitem>
-       <para>Documented the deprecation of stonith and orphan terminology in Pacemaker (<link xlink:href="index.html#jsc-PED-15950">jsc#PED-15950</link>)</para>
+       <para>Documented the <link xlink:href="index.html#jsc-PED-15950">deprecation of stonith and orphan terminology in Pacemaker</link></para>
       </listitem>
      </itemizedlist>
     </revdescription>

--- a/adoc/sleha/version161.adoc
+++ b/adoc/sleha/version161.adoc
@@ -41,4 +41,16 @@ Customers who use csync2 can now run `crm cluster init csync2 -y` to set it up s
 
 This section lists features and packages that were removed from {productname} or will be removed in upcoming versions.
 
+// jsc#PED-15950
+* The terms `stonith` and `orphan` have been deprecated in Pacemaker in favor of `fencing` and `removed`.
+  The old configuration properties are still supported but are marked as deprecated, and their corresponding new names should be used instead:
+** `stonith-enabled` is now `fencing-enabled`
+** `stonith-action` is now `fencing-action`
+** `stonith-max-attempts` is now `fencing-max-attempts`
+** `stonith-timeout` is now `fencing-timeout`
+** `stonith-watchdog-timeout` is now `fencing-watchdog-timeout`
+** `fence-reaction` is now `fencing-reaction`
+** `stop-orphan-resources` is now `stop-removed-resources`
+** `stop-orphan-actions` is now `cancel-removed-actions` (jsc#PED-15950)
+
 *  `sctp` support has been deprecated in `kronosnet` and to be removed upstream in 2.x

--- a/adoc/sleha/version161.adoc
+++ b/adoc/sleha/version161.adoc
@@ -41,16 +41,6 @@ Customers who use csync2 can now run `crm cluster init csync2 -y` to set it up s
 
 This section lists features and packages that were removed from {productname} or will be removed in upcoming versions.
 
-// jsc#PED-15950
-* The terms `stonith` and `orphan` have been deprecated in Pacemaker in favor of `fencing` and `removed`.
-  The old configuration properties are still supported but are marked as deprecated, and their corresponding new names should be used instead:
-** `stonith-enabled` is now `fencing-enabled`
-** `stonith-action` is now `fencing-action`
-** `stonith-max-attempts` is now `fencing-max-attempts`
-** `stonith-timeout` is now `fencing-timeout`
-** `stonith-watchdog-timeout` is now `fencing-watchdog-timeout`
-** `fence-reaction` is now `fencing-reaction`
-** `stop-orphan-resources` is now `stop-removed-resources`
-** `stop-orphan-actions` is now `cancel-removed-actions` (jsc#PED-15950)
-
 *  `sctp` support has been deprecated in `kronosnet` and to be removed upstream in 2.x
+
+include::../shared.adoc[tags=jscped-15950,leveloffset=+3]

--- a/adoc/slesap/release-notes-slesap-161-docinfo.xml
+++ b/adoc/slesap/release-notes-slesap-161-docinfo.xml
@@ -18,7 +18,7 @@
        <para>Documented that NVIDIA KMPs are not available for the real-time kernel (<link xlink:href="index.html#jsc-PED-16382">jsc#PED-16382</link>)</para>
       </listitem>
       <listitem>
-       <para>Documented the deprecation of stonith and orphan terminology in Pacemaker (<link xlink:href="index.html#deprecated-slesap">jsc#PED-15950</link>)</para>
+       <para>Documented the deprecation of stonith and orphan terminology in Pacemaker (<link xlink:href="index.html#jsc-PED-15950">jsc#PED-15950</link>)</para>
       </listitem>
      </itemizedlist>
     </revdescription>

--- a/adoc/slesap/release-notes-slesap-161-docinfo.xml
+++ b/adoc/slesap/release-notes-slesap-161-docinfo.xml
@@ -18,7 +18,7 @@
        <para>Documented that NVIDIA KMPs are not available for the real-time kernel (<link xlink:href="index.html#jsc-PED-16382">jsc#PED-16382</link>)</para>
       </listitem>
       <listitem>
-       <para>Documented the <link xlink:href="index.html#jsc-PED-15950">deprecation of stonith and orphan terminology in Pacemaker</link></para>
+       <para>Documented the deprecation of stonith and orphan terminology in Pacemaker (<link xlink:href="index.html#jsc-PED-15950">jsc#PED-15950</link>)</para>
       </listitem>
      </itemizedlist>
     </revdescription>

--- a/adoc/slesap/release-notes-slesap-161-docinfo.xml
+++ b/adoc/slesap/release-notes-slesap-161-docinfo.xml
@@ -18,7 +18,7 @@
        <para>Documented that NVIDIA KMPs are not available for the real-time kernel (<link xlink:href="index.html#jsc-PED-16382">jsc#PED-16382</link>)</para>
       </listitem>
       <listitem>
-       <para>Documented the deprecation of stonith and orphan terminology in Pacemaker (<link xlink:href="index.html#jsc-PED-15950">jsc#PED-15950</link>)</para>
+       <para>Documented the <link xlink:href="index.html#jsc-PED-15950">deprecation of stonith and orphan terminology in Pacemaker</link></para>
       </listitem>
      </itemizedlist>
     </revdescription>

--- a/adoc/slesap/release-notes-slesap-161-docinfo.xml
+++ b/adoc/slesap/release-notes-slesap-161-docinfo.xml
@@ -17,6 +17,9 @@
       <listitem>
        <para>Documented that NVIDIA KMPs are not available for the real-time kernel (<link xlink:href="index.html#jsc-PED-16382">jsc#PED-16382</link>)</para>
       </listitem>
+      <listitem>
+       <para>Documented the deprecation of stonith and orphan terminology in Pacemaker (<link xlink:href="index.html#deprecated-slesap">jsc#PED-15950</link>)</para>
+      </listitem>
      </itemizedlist>
     </revdescription>
   </revision>

--- a/adoc/slesap/version161.adoc
+++ b/adoc/slesap/version161.adoc
@@ -62,15 +62,27 @@ The following features and packages have been removed in this release.
 * The HA solution for NetWeaver central services is not supported.
 See https://documentation.suse.com/releasenotes/sles-sap/15-SP7/index.html#jsc-PED-11566 for more information. (bsc#1274569)
 
-// [#deprecated]
-// === Deprecated features and packages
+[#deprecated-slesap]
+=== Deprecated features and packages
 
 ////
 1. Deprecations that will be removed in an upcoming service pack of current SLE major version:
 2. Deprecations that will be removed in the next SLE major version:
-3. Deprecations that will be removed later or where removal timing is unclear:
+3. Deprecations—that will be removed later or where removal timing is unclear:
 ////
 
-// The following features and packages are deprecated and will be removed in a future version of {productname}.
+The following features and packages are deprecated and will be removed in a future version of {productname}.
+
+// jsc#PED-15950
+* The terms `stonith` and `orphan` have been deprecated in Pacemaker in favor of `fencing` and `removed`.
+  The old configuration properties are still supported but are marked as deprecated, and their corresponding new names should be used instead:
+** `stonith-enabled` is now `fencing-enabled`
+** `stonith-action` is now `fencing-action`
+** `stonith-max-attempts` is now `fencing-max-attempts`
+** `stonith-timeout` is now `fencing-timeout`
+** `stonith-watchdog-timeout` is now `fencing-watchdog-timeout`
+** `fence-reaction` is now `fencing-reaction`
+** `stop-orphan-resources` is now `stop-removed-resources`
+** `stop-orphan-actions` is now `cancel-removed-actions` (jsc#PED-15950)
 
 

--- a/adoc/slesap/version161.adoc
+++ b/adoc/slesap/version161.adoc
@@ -73,16 +73,6 @@ See https://documentation.suse.com/releasenotes/sles-sap/15-SP7/index.html#jsc-P
 
 The following features and packages are deprecated and will be removed in a future version of {productname}.
 
-// jsc#PED-15950
-* The terms `stonith` and `orphan` have been deprecated in Pacemaker in favor of `fencing` and `removed`.
-  The old configuration properties are still supported but are marked as deprecated, and their corresponding new names should be used instead:
-** `stonith-enabled` is now `fencing-enabled`
-** `stonith-action` is now `fencing-action`
-** `stonith-max-attempts` is now `fencing-max-attempts`
-** `stonith-timeout` is now `fencing-timeout`
-** `stonith-watchdog-timeout` is now `fencing-watchdog-timeout`
-** `fence-reaction` is now `fencing-reaction`
-** `stop-orphan-resources` is now `stop-removed-resources`
-** `stop-orphan-actions` is now `cancel-removed-actions` (jsc#PED-15950)
+include::../shared.adoc[tags=jscped-15950,leveloffset=+3]
 
 


### PR DESCRIPTION
This PR adds the release note documenting the deprecation of 'stonith' and 'orphan' configuration properties in Pacemaker, replacing them with 'fencing' and 'removed'. These changes apply to SLE HA 16.1 and SLES for SAP 16.1. Relates to jsc#PED-15950.