### PR TITLE
SLES 16.1: Document coexistence of zlib and zlib-ng (jsc#PED-15892)

### DIFF
--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -15,6 +15,9 @@
     <revdescription>
      <itemizedlist>
       <listitem>
+       <para>Documented the coexistence of zlib and zlib-ng compression libraries (<link xlink:href="index.html#jsc-PED-15892">jsc#PED-15892</link>)</para>
+      </listitem>
+      <listitem>
        <para>Added section <link xlink:href="index.html#jsc-PED-16083">Unified systemd service presets between standard and immutable modes</link> (jsc#PED-16083)</para>
       </listitem>
       <listitem>

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -174,6 +174,13 @@ See <<jsc-PED-16106>>.
 // jsc#PED-12658
 * `rasdaemon` has been updated to version 0.8.4. This version supports machine checks related to CXL memory. Since Intel® Optane™ Memory products have reached End of Life (EOL), {productname} {this-version} does not support them either.
 
+[#jsc-PED-15892]
+=== Coexistence of zlib and zlib-ng libraries
+
+{productname} {this-version} now includes both the traditional `zlib` and the newer, high-performance `zlib-ng` compression libraries.
+The `zlib-ng` library provides substantial performance optimizations by utilizing modern CPU instruction sets.
+While both libraries are fully supported in this release, SUSE intends to only support `zlib-ng` in the future.
+
 [#jsc-PED-16083]
 === Unified systemd service presets between standard and immutable modes
 


### PR DESCRIPTION
Documents the addition of zlib-ng alongside zlib in SLES 16.1 (Jira: PED-15892).