### PR TITLE
SLES 16.1: Document supported upgrade and migration paths (jsc#PED-14891)

### DIFF
--- a/adoc/common/attributes-generic.adoc
+++ b/adoc/common/attributes-generic.adoc
@@ -162,7 +162,7 @@
 // openSUSE VARIANTS
 :opensuse:                   openSUSE
 :osuse:                      {opensuse}
-:os:                         opensuse}
+:os:                         {opensuse}
 :opensusereg:                {opensuse}{thrdmrk}
 :leap:                       {os} Leap
 :tw:                         {os} Tumbleweed
@@ -756,4 +756,3 @@ endif::[]
 ifeval::["{lifecycle}" == ""]
 :lifecycle: unmaintained
 endif::[]
-

--- a/adoc/sles/attributes-version161.adoc
+++ b/adoc/sles/attributes-version161.adoc
@@ -11,9 +11,11 @@
 // ifeval::["{lifecycle}" == "maintained"]
 :url-sle-comparison: https://documentation.suse.com/sles-sap/16.0/html/SLE-comparison/index.html
 :url-gnome-remote-desktop: https://documentation.suse.com/sles/16.0/html/SLES-gnome-remote-desktop/index.html
+:url-sles-upgrade: https://documentation.suse.com/sles/16.1/html/SLES-upgrading/
 // endif::[]
 
 ifeval::["{lifecycle}" == "beta"]
 :url-sle-comparison: https://susedoc.github.io/doc-modular/main/html/SLE-comparison/index.html
 :url-gnome-remote-desktop: https://susedoc.github.io/doc-modular/main/html/SLES-gnome-remote-desktop/
+:url-sles-upgrade: https://susedoc.github.io/doc-modular/main/html/SLES-upgrading/
 endif::[]

--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -15,6 +15,9 @@
     <revdescription>
      <itemizedlist>
       <listitem>
+       <para>Added section <link xlink:href="index.html#jsc-PED-14891">Supported upgrade and migration paths</link> (jsc#PED-14891)</para>
+      </listitem>
+      <listitem>
        <para>Added section <link xlink:href="index.html#jsc-PED-15419">Pressure Stall Information (PSI) enabled by default</link> (jsc#PED-15419)</para>
       </listitem>
       <listitem>

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -145,6 +145,20 @@ You can check packages included in products on https://scc.suse.com.
 
 Installation media, VM images and public cloud images are usually refreshed every 3 months (Quarterly Updates).
 
+[#jsc-PED-14891]
+== Supported upgrade and migration paths
+
+{productname} {this-version} supports upgrading from {productname} 16.0, as well as migrating from preceding {suse} product releases.
+
+* **Online (in-place) upgrade** is supported from {productname} 16.0 (including {slessapa} and {sleha}).
+* **Offline migration** (using offline installation media) is supported from:
+  ** {productname} 15 SP4, SP5, SP6, and SP7 (including {slessapa} and {sleha})
+  ** SUSE Linux Micro 6.2
+  ** SUSE Linux Enterprise Real Time 15 SP7
+  ** openSUSE Leap 16.1
+
+For detailed instructions, pre-upgrade checklists, and step-by-step migration procedures, see the link:{url-sles-upgrade}[Upgrade Guide].
+
 [#upgrade-checklist]
 == Upgrade and migration checklist
 
@@ -153,6 +167,7 @@ Before upgrading to {productname} {this-version}, review the following checklist
 === Before upgrading
 
 * <<jsc-PED-14664>>
+* <<jsc-PED-14891>>
 
 === During upgrade
 

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -153,9 +153,9 @@ Installation media, VM images and public cloud images are usually refreshed ever
 * **Online (in-place) upgrade** is supported from {productname} 16.0 (including {slessapa} and {sleha}).
 * **Offline migration** (using offline installation media) is supported from:
   ** {productname} 15 SP4, SP5, SP6, and SP7 (including {slessapa} and {sleha})
-  ** SUSE Linux Micro 6.2
-  ** SUSE Linux Enterprise Real Time 15 SP7
-  ** openSUSE Leap 16.1
+  ** {slem} 6.2
+  ** {slert} 15 SP7
+  ** {leap} 16.1
 
 For detailed instructions, pre-upgrade checklists, and step-by-step migration procedures, see the link:{url-sles-upgrade}[Upgrade Guide].
 


### PR DESCRIPTION
This PR documents the supported online and offline upgrade/migration paths for SLES 16.1, pointing to the official SLES Upgrade Guide.