### PR TITLE
SLES 16.1: Add note about BPF subsystem updates (jsc#PED-14654)

### DIFF
--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-08-18</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Added section <link xlink:href="index.html#jsc-PED-14654">Linux kernel BPF subsystem updated to match upstream v6.13 to v6.18</link> (jsc#PED-14654)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-08-17</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/sles/release-notes-sles-161.adoc
+++ b/adoc/sles/release-notes-sles-161.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version161.adoc[]
 
 = SUSE Linux Enterprise Server Release Notes
-:revdate: 2026-08-17
+:revdate: 2026-08-18
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -183,6 +183,17 @@ Before upgrading to {productname} {this-version}, review the following checklist
 // jsc#PED-12658
 * `rasdaemon` has been updated to version 0.8.4. This version supports machine checks related to CXL memory. Since Intel® Optane™ Memory products have reached End of Life (EOL), {productname} {this-version} does not support them either.
 
+[#jsc-PED-14654]
+=== Linux kernel BPF subsystem updated to match upstream v6.13 to v6.18
+
+The Berkeley Packet Filter (BPF) subsystem in the Linux kernel has been updated to align with the upstream kernel versions v6.13 through v6.18.
+
+Key changes and system requirements:
+
+* To maintain compatibility and prevent breakage of third-party out-of-tree kernel modules, kABI padding has been applied to twelve key BPF structures (including `bpf_insn_aux_data`, `bpf_link`, `bpf_mem_alloc`, `bpf_mprog_bundle`, `bpf_reg_state`, `bpf_verifier_log`, and `hid_bpf`).
+* Bypassing global per-protocol socket memory accounting is now supported by configuring a network namespace sysctl.
+* See the upstream kernel changelogs from https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.13 through https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.18.
+
 [#jsc-PED-15419]
 === Pressure Stall Information (PSI) enabled by default
 


### PR DESCRIPTION
This PR adds a focused release note for the Linux kernel BPF subsystem update in SLES 16.1 (jsc#PED-14654).