### PR TITLE
SLES 16.0, SLES 16.1: Document deprecation of legacy XFS v4 filesystem format (bsc#1275537)

### DIFF
--- a/adoc/shared.adoc
+++ b/adoc/shared.adoc
@@ -361,3 +361,44 @@ The old configuration properties are still supported but are marked as deprecate
 * `stop-orphan-actions` is now `cancel-removed-actions`
 end::jscped-15950[]
 
+tag::bsc1275537[]
+[#bsc-1275537]
+= Deprecation of legacy XFS v4 filesystem format
+
+{sle} maintains backward compatibility for legacy XFS v4 filesystems via the kernel configuration `CONFIG_XFS_SUPPORT_V4=y`.
+This support ensures uninterrupted access for existing environments.
+However, XFS v4 is deprecated, and creating new v4 filesystems is strongly discouraged.
+
+September 2030 is the EOL target for upstream Linux kernel support for XFS v4.
+Any release post-September 2030 based on updated upstream kernels will omit XFS v4 support entirely.
+Legacy v4 filesystems will no longer be mountable on those versions.
+
+Upgrading underlying filesystems from v4 to v5 is transparent to applications and requires no changes to userspace software.
+
+To check the format version of an existing XFS filesystem, run:
+[source]
+----
+xfs_info /path/to/mountpoint
+----
+An output including `crc=1` indicates the modern v5 format, while `crc=0` indicates the legacy v4 format.
+
+There is no in-place or online upgrade path from XFS v4 to v5.
+Migration requires backing up data, reformatting the block device to XFS v5, and restoring the content.
+Migrating the root filesystem and any other critical data partitions requires planned downtime.
+
+The operating system generates warnings when v4 format interaction occurs:
+
+* `mkfs.xfs` displays a warning if forced to format as v4 (`crc=0`):
++
+[screen]
+----
+V4 filesystems are deprecated and will not be supported by future versions
+----
+* The kernel logs a notification upon mounting a v4 filesystem (printed once per boot cycle, upon first mount of a v4 filesystem):
++
+[screen]
+----
+Deprecated V4 format (crc=0) will not be supported after September 2030.
+----
+end::bsc1275537[]
+

--- a/adoc/sles/release-notes-sles-160-docinfo.xml
+++ b/adoc/sles/release-notes-sles-160-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xml:id="revhistory" xmlns:xlink="http://www.w3.org/1999/xlink">
     <revision>
+     <date>2026-08-18</date>
+     <revdescription>
+      <itemizedlist>
+       <listitem>
+        <para>Added section <link xlink:href="index.html#bsc-1275537">Deprecation of legacy XFS v4 filesystem format</link> (bsc#1275537)</para>
+       </listitem>
+      </itemizedlist>
+     </revdescription>
+    </revision>
+    <revision>
      <date>2026-08-04</date>
      <revdescription>
       <itemizedlist>

--- a/adoc/sles/release-notes-sles-160.adoc
+++ b/adoc/sles/release-notes-sles-160.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version160.adoc[]
 
 = SUSE Linux Enterprise Server Release Notes
-:revdate: 2026-08-04
+:revdate: 2026-08-18
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -15,6 +15,9 @@
     <revdescription>
      <itemizedlist>
       <listitem>
+       <para>Added section <link xlink:href="index.html#bsc-1275537">Deprecation of legacy XFS v4 filesystem format</link> (bsc#1275537)</para>
+      </listitem>
+      <listitem>
        <para>Added section <link xlink:href="index.html#jsc-PED-14654">Linux kernel BPF subsystem updated to match upstream v6.13 to v6.18</link> (jsc#PED-14654)</para>
       </listitem>
       <listitem>

--- a/adoc/sles/version160.adoc
+++ b/adoc/sles/version160.adoc
@@ -231,6 +231,9 @@ include::../shared.adoc[tags=jscped-15282,leveloffset=+2]
 // bsc#1271333
 include::../shared.adoc[tags=bsc1271333,leveloffset=+2]
 
+// bsc#1275537
+include::../shared.adoc[tags=bsc1275537,leveloffset=+2]
+
 // jsc#PED-13286
 // bsc#1245474
 [#jsc-PED-13286]
@@ -1343,6 +1346,10 @@ include::../shared.adoc[tags=jscped12374]
 ////
 
 The following features and packages are deprecated and will be removed in a future version of {productname}.
+
+// bsc#1275537
+* Legacy XFS v4 filesystems are deprecated.
+  For details, see <<bsc-1275537>>.
 
 // jsc#PED-16117
 * The DCCP protocol is deprecated in {productname} 16.0 and will be disabled in {productname} 16.1.

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -261,6 +261,9 @@ include::../shared.adoc[tags=jscped-15282,leveloffset=+2]
 // bsc#1271333
 include::../shared.adoc[tags=bsc1271333,leveloffset=+2]
 
+// bsc#1275537
+include::../shared.adoc[tags=bsc1275537,leveloffset=+2]
+
 [#jsc-PED-14453]
 === SDL 3 and sdl2-compat update
 
@@ -719,6 +722,10 @@ The following features and packages have been removed in this release.
 ////
 
 The following features and packages are deprecated and will be removed in a future version of {productname}.
+
+// bsc#1275537
+* Legacy XFS v4 filesystems are deprecated.
+  For details, see <<bsc-1275537>>.
 
 // jsc#PED-16257
 * The following SSSD features and options are deprecated in {productname} 16.1 and are planned for removal in {productname} 16.2:


### PR DESCRIPTION
Documents the deprecation of the legacy XFS v4 filesystem format in SLES 16.0 and SLES 16.1 (bsc#1275537).