### PR TITLE
SLES 16.0, SLE Micro 6.0: Document disabled 32-bit execution support (jsc#PED-10546)

### DIFF
--- a/adoc/micro/release-notes-micro-60.adoc
+++ b/adoc/micro/release-notes-micro-60.adoc
@@ -4,7 +4,7 @@ include::attributes.adoc[]
 :this-version: 6.0
 
 = SL Micro Release Notes
-:revdate: 2026-04-01
+:revdate: 2026-08-18
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/micro/version60.adoc
+++ b/adoc/micro/version60.adoc
@@ -86,6 +86,9 @@ Information in this section applies to all architectures supported by {productna
 // SHA1 disabled
 include::../shared.adoc[tags=jscped-12210,leveloffset=+2]
 
+// jsc#PED-10546
+include::../shared.adoc[tags=jscped-10546,leveloffset=+2]
+
 
 === Full-disk encryption
 

--- a/adoc/shared.adoc
+++ b/adoc/shared.adoc
@@ -403,6 +403,8 @@ Deprecated V4 format (crc=0) will not be supported after September 2030.
 end::bsc1275537[]
 
 tag::jscped-10546[]
+// jsc#PED-10546
+// jsc#PED-3184
 [#jsc-PED-10546]
 = 32-bit execution support disabled by default on {x64} and {aarch64}
 
@@ -410,6 +412,5 @@ On the {x64} and {arm} 64-bit ({aarch64}) architectures, support for running 32-
 To re-enable 32-bit execution on the {x64} architecture, boot the system with the `ia32_emulation=1` kernel parameter.
 To re-enable 32-bit execution on the {aarch64} architecture (provided the hardware physically supports AArch32), ensure that the `arm64.no32bit_el0` kernel parameter is not set.
 Other architectures are not affected by this change.
-(jsc#PED-10546, jsc#PED-3184)
 end::jscped-10546[]
 

--- a/adoc/shared.adoc
+++ b/adoc/shared.adoc
@@ -402,3 +402,14 @@ Deprecated V4 format (crc=0) will not be supported after September 2030.
 ----
 end::bsc1275537[]
 
+tag::jscped-10546[]
+[#jsc-PED-10546]
+= 32-bit execution support disabled by default on {x64} and {aarch64}
+
+On the {x64} and {arm} 64-bit ({aarch64}) architectures, support for running 32-bit (AArch32 and ia32) applications has been disabled by default to reduce the system's security attack surface.
+To re-enable 32-bit execution on the {x64} architecture, boot the system with the `ia32_emulation=1` kernel parameter.
+To re-enable 32-bit execution on the {aarch64} architecture (provided the hardware physically supports AArch32), ensure that the `arm64.no32bit_el0` kernel parameter is not set.
+Other architectures are not affected by this change.
+(jsc#PED-10546, jsc#PED-3184)
+end::jscped-10546[]
+

--- a/adoc/sles/release-notes-sles-160-docinfo.xml
+++ b/adoc/sles/release-notes-sles-160-docinfo.xml
@@ -15,6 +15,9 @@
      <revdescription>
       <itemizedlist>
        <listitem>
+        <para>Added section <link xlink:href="index.html#jsc-PED-10546">32-bit execution support disabled by default on {x64} and {aarch64}</link> (jsc#PED-10546)</para>
+       </listitem>
+       <listitem>
         <para>Added section <link xlink:href="index.html#bsc-1275537">Deprecation of legacy XFS v4 filesystem format</link> (bsc#1275537)</para>
        </listitem>
       </itemizedlist>

--- a/adoc/sles/version160.adoc
+++ b/adoc/sles/version160.adoc
@@ -180,6 +180,9 @@ See <<jsc-PED-6311>>.
 // jsc#PED-11656
 * We now provide a unified image that can be used to install either {slesa} or {slessapa}
 
+// jsc#PED-10546
+include::../shared.adoc[tags=jscped-10546,leveloffset=+2]
+
 [#jsc-PED-15411]
 === GNOME Software is now available and supports online updates
 


### PR DESCRIPTION
This PR adds a shared release note under 'Changes affecting all architectures' in both SLES 16.0 and SLE Micro 6.0, documenting that 32-bit user-space support has been disabled by default. It also provides instructions for re-enabling support on x86_64 and AArch64 systems.