### PR TITLE
SLES 16.0, SLES 16.1, SLE Micro 6.0, SLE Micro 6.1: Add note about SLE BCI for kernel modules (jsc#PED-5576)

### DIFF
--- a/adoc/micro/release-notes-micro-60-docinfo.xml
+++ b/adoc/micro/release-notes-micro-60-docinfo.xml
@@ -9,7 +9,17 @@
 <productname>{productname}</productname>
 <productnumber>{this-version}</productnumber>
 <date>{revdate}</date>
-<revhistory>
+<revhistory xmlns:xlink="http://www.w3.org/1999/xlink">
+  <revision>
+    <date>2026-08-19</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Added section <link xlink:href="index.html#jsc-PED-5576">SLE BCI for kernel modules (Driver Toolkit)</link> (jsc#PED-5576)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
   <revision>
     <date>{revdate}</date>
   </revision>

--- a/adoc/micro/release-notes-micro-60.adoc
+++ b/adoc/micro/release-notes-micro-60.adoc
@@ -4,7 +4,7 @@ include::attributes.adoc[]
 :this-version: 6.0
 
 = SL Micro Release Notes
-:revdate: 2026-08-18
+:revdate: 2026-08-19
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/micro/release-notes-micro-61-docinfo.xml
+++ b/adoc/micro/release-notes-micro-61-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-08-19</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Added section <link xlink:href="index.html#jsc-PED-5576">SLE BCI for kernel modules (Driver Toolkit)</link> (jsc#PED-5576)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-07-17</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/micro/release-notes-micro-61.adoc
+++ b/adoc/micro/release-notes-micro-61.adoc
@@ -4,7 +4,7 @@ include::attributes.adoc[]
 :this-version: 6.1
 
 = SL Micro Release Notes
-:revdate: 2026-07-28
+:revdate: 2026-08-19
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/micro/version60.adoc
+++ b/adoc/micro/version60.adoc
@@ -86,6 +86,9 @@ Information in this section applies to all architectures supported by {productna
 // SHA1 disabled
 include::../shared.adoc[tags=jscped-12210,leveloffset=+2]
 
+// jsc#PED-5576
+include::../shared.adoc[tags=jscped-5576,leveloffset=+2]
+
 // jsc#PED-10546
 include::../shared.adoc[tags=jscped-10546,leveloffset=+2]
 

--- a/adoc/micro/version61.adoc
+++ b/adoc/micro/version61.adoc
@@ -11,6 +11,9 @@ These release notes apply to {productname} {this-version}.
 
 === Changes affecting all architectures
 
+// jsc#PED-5576
+include::../shared.adoc[tags=jscped-5576,leveloffset=+3]
+
 // jsc#PED-12879
 include::../shared.adoc[tags=jscped-12879,leveloffset=+3]
 

--- a/adoc/shared.adoc
+++ b/adoc/shared.adoc
@@ -414,3 +414,11 @@ To re-enable 32-bit execution on the {aarch64} architecture (provided the hardwa
 Other architectures are not affected by this change.
 end::jscped-10546[]
 
+tag::jscped-5576[]
+[#jsc-PED-5576]
+= SLE BCI for kernel modules (Driver Toolkit)
+
+A new Base Container Image (BCI) is now available to build and run kernel modules on {productname}, comparable to the upstream `driver-toolkit`.
+The container includes the necessary kernel headers for both default and RT kernels on `x86_64` and `aarch64` architectures, providing a simple way to prototype and test drivers without giving access to SLE kernel binaries.
+end::jscped-5576[]
+

--- a/adoc/sles/release-notes-sles-160-docinfo.xml
+++ b/adoc/sles/release-notes-sles-160-docinfo.xml
@@ -17,6 +17,9 @@
        <listitem>
         <para>Changed SAP Netweaver to SAP S/4HANA in <link xlink:href="index.html#jsc-PED-15191">OpenLDAP 2.4 compatibility package</link> (bsc#1275645)</para>
        </listitem>
+       <listitem>
+        <para>Added section <link xlink:href="index.html#jsc-PED-5576">SLE BCI for kernel modules (Driver Toolkit)</link> (jsc#PED-5576)</para>
+       </listitem>
       </itemizedlist>
      </revdescription>
     </revision>

--- a/adoc/sles/release-notes-sles-160.adoc
+++ b/adoc/sles/release-notes-sles-160.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version160.adoc[]
 
 = SUSE Linux Enterprise Server Release Notes
-:revdate: 2026-08-18
+:revdate: 2026-08-19
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-08-19</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Added section <link xlink:href="index.html#jsc-PED-5576">SLE BCI for kernel modules (Driver Toolkit)</link> (jsc#PED-5576)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-08-18</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/sles/release-notes-sles-161.adoc
+++ b/adoc/sles/release-notes-sles-161.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version161.adoc[]
 
 = SUSE Linux Enterprise Server Release Notes
-:revdate: 2026-08-18
+:revdate: 2026-08-19
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/sles/version160.adoc
+++ b/adoc/sles/version160.adoc
@@ -180,6 +180,9 @@ See <<jsc-PED-6311>>.
 // jsc#PED-11656
 * We now provide a unified image that can be used to install either {slesa} or {slessapa}
 
+// jsc#PED-5576
+include::../shared.adoc[tags=jscped-5576,leveloffset=+2]
+
 // jsc#PED-10546
 include::../shared.adoc[tags=jscped-10546,leveloffset=+2]
 

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -183,6 +183,9 @@ Before upgrading to {productname} {this-version}, review the following checklist
 // jsc#PED-12658
 * `rasdaemon` has been updated to version 0.8.4. This version supports machine checks related to CXL memory. Since Intel® Optane™ Memory products have reached End of Life (EOL), {productname} {this-version} does not support them either.
 
+// jsc#PED-5576
+include::../shared.adoc[tags=jscped-5576,leveloffset=+2]
+
 [#jsc-PED-14654]
 === Linux kernel BPF subsystem updated to match upstream v6.13 to v6.18
 


### PR DESCRIPTION
Adds the shared, tagged release note for SLE BCI for kernel modules (driver toolkit).