### PR TITLE
SLES 16.0, 16.1, 16.2: Add PINT link to online documentation section (docteam#351)

### DIFF
--- a/adoc/common/about-documentation.adoc
+++ b/adoc/common/about-documentation.adoc
@@ -17,3 +17,6 @@ endif::[]
 ifeval::["{lifecycle}" == "unmaintained"]
 *  {doc-url}.
 endif::[]
+
+// docteam#351
+* Find change logs for public cloud images at the Public Cloud Information Tracker (PINT) at https://pint.suse.com/.

--- a/adoc/sles/release-notes-sles-160-docinfo.xml
+++ b/adoc/sles/release-notes-sles-160-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xml:id="revhistory" xmlns:xlink="http://www.w3.org/1999/xlink">
     <revision>
+     <date>2026-08-25</date>
+     <revdescription>
+      <itemizedlist>
+       <listitem>
+        <para>Added link to the Public Cloud Information Tracker (PINT) to <link xlink:href="index.html#intro-documentation">Documentation and other information</link> (docteam#351)</para>
+       </listitem>
+      </itemizedlist>
+     </revdescription>
+    </revision>
+    <revision>
      <date>2026-08-19</date>
      <revdescription>
       <itemizedlist>

--- a/adoc/sles/release-notes-sles-160.adoc
+++ b/adoc/sles/release-notes-sles-160.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version160.adoc[]
 
 = SUSE Linux Enterprise Server Release Notes
-:revdate: 2026-08-19
+:revdate: 2026-08-25
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-08-25</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Added link to the Public Cloud Information Tracker (PINT) to <link xlink:href="index.html#intro-documentation">Documentation and other information</link> (docteam#351)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-08-19</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/sles/release-notes-sles-161.adoc
+++ b/adoc/sles/release-notes-sles-161.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version161.adoc[]
 
 = SUSE Linux Enterprise Server Release Notes
-:revdate: 2026-08-19
+:revdate: 2026-08-25
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/sles/release-notes-sles-162-docinfo.xml
+++ b/adoc/sles/release-notes-sles-162-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-08-25</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Added link to the Public Cloud Information Tracker (PINT) to <link xlink:href="index.html#intro-documentation">Documentation and other information</link> (docteam#351)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-07-22</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/sles/release-notes-sles-162.adoc
+++ b/adoc/sles/release-notes-sles-162.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version162.adoc[]
 
 = SUSE Linux Enterprise Server Release Notes
-:revdate: 2026-07-22
+:revdate: 2026-08-25
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.


### PR DESCRIPTION
Add link to pint.suse.com to SLES 16.0, 16.1, and 16.2 Release Notes Online documentation.