### PR TITLE
SLES 16.1: Document removal of unmaintained python-pytest-forked package (jsc#PED-16582)

### DIFF
--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -17,6 +17,9 @@
       <listitem>
        <para>Added link to the Public Cloud Information Tracker (PINT) to <link xlink:href="index.html#intro-documentation">Documentation and other information</link> (docteam#351)</para>
       </listitem>
+      <listitem>
+       <para>Documented removal of unmaintained python-pytest-forked package (<link xlink:href="index.html#removed">jsc#PED-16582</link>)</para>
+      </listitem>
      </itemizedlist>
     </revdescription>
   </revision>

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -693,11 +693,13 @@ The following features and packages have been removed in this release.
   Applications relying on SDL 2.0 now utilize the `sdl2-compat` compatibility layer.
 
 // jsc#PED-16696
+// jsc#PED-16582
 // jsc#PED-16555
 // jsc#PED-16552
 // jsc#PED-16549
 * Due to being no longer maintained, these packages have been removed from {productname} 16.1:
 ** `fwts`
+** `python-pytest-forked`
 ** `perl-Test-Output`
 ** `perl-Test-Needs`
 ** `perl-Test-Differences`


### PR DESCRIPTION
This PR documents the removal of the unmaintained `python-pytest-forked` package from SLES 16.1, as requested in [PED-16582](https://jira.suse.com/browse/PED-16582).