### PR TITLE
SLES 16.0: Add PCP 6.2.0 upgrade release notes (jsc#PED-8349)

### DIFF
--- a/adoc/sles/release-notes-sles-160-docinfo.xml
+++ b/adoc/sles/release-notes-sles-160-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xml:id="revhistory" xmlns:xlink="http://www.w3.org/1999/xlink">
     <revision>
+     <date>2026-08-26</date>
+     <revdescription>
+      <itemizedlist>
+       <listitem>
+        <para>Added section <link xlink:href="index.html#jsc-PED-8349">Performance Co-Pilot (PCP) upgraded to version 6.2.0</link> (jsc#PED-8349)</para>
+       </listitem>
+      </itemizedlist>
+     </revdescription>
+    </revision>
+    <revision>
      <date>2026-08-25</date>
      <revdescription>
       <itemizedlist>

--- a/adoc/sles/release-notes-sles-160.adoc
+++ b/adoc/sles/release-notes-sles-160.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version160.adoc[]
 
 = SUSE Linux Enterprise Server Release Notes
-:revdate: 2026-08-25
+:revdate: 2026-08-26
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/sles/version160.adoc
+++ b/adoc/sles/version160.adoc
@@ -180,6 +180,15 @@ See <<jsc-PED-6311>>.
 // jsc#PED-11656
 * We now provide a unified image that can be used to install either {slesa} or {slessapa}
 
+// bsc#1217826
+[#jsc-PED-8349]
+=== Performance Co-Pilot (PCP) upgraded to version 6.2.0
+
+Performance Co-Pilot (PCP) has been upgraded to version 6.2.0.
+This version upgrade resolves multiple security vulnerabilities, including CVE-2023-6917.
+The upgrade also includes several new features and performance enhancements.
+For a complete list of changes, see the upstream release notes at link:https://pcp.io/[] and the package changelog.
+
 // jsc#PED-5576
 include::../shared.adoc[tags=jscped-5576,leveloffset=+2]
 


### PR DESCRIPTION
Upgrade Performance Co-Pilot (PCP) to version 6.2.0 to resolve multiple security vulnerabilities including CVE-2023-6917.