### PR TITLE
SLES 16.0: Document direct migration support from SLES 15 SP6 (jsc#PED-14578)

### DIFF
--- a/adoc/sles/release-notes-sles-160-docinfo.xml
+++ b/adoc/sles/release-notes-sles-160-docinfo.xml
@@ -15,6 +15,9 @@
      <revdescription>
       <itemizedlist>
        <listitem>
+        <para>Added section <link xlink:href="index.html#jsc-PED-14578">Direct migration from SLES 15 SP6 is supported</link> (jsc#PED-14578)</para>
+       </listitem>
+       <listitem>
         <para>Added section <link xlink:href="index.html#jsc-PED-8349">Performance Co-Pilot (PCP) upgraded to version 6.2.0</link> (jsc#PED-8349)</para>
        </listitem>
       </itemizedlist>

--- a/adoc/sles/version160.adoc
+++ b/adoc/sles/version160.adoc
@@ -128,6 +128,8 @@ Before upgrading to {productname} {this-version}, review the following checklist
 
 === Before upgrading
 
+* <<jsc-PED-14578>>
+
 * *Network Teaming:* Network teaming (`teamd`) has been removed.
 +
 Migrate configurations to NetworkManager bonding.
@@ -179,6 +181,17 @@ See <<jsc-PED-6311>>.
 * `NetworkManager` is now the only network configuration stack in {productname} {this-version}.
 // jsc#PED-11656
 * We now provide a unified image that can be used to install either {slesa} or {slessapa}
+
+// jsc#PED-14578
+// bsc#1261164
+[#jsc-PED-14578]
+=== Direct migration from SLES 15 SP6 is supported
+
+SUSE now officially supports direct migration from {sles} 15 SP6 to {productname} {this-version}.
+This direct path enables migration without an interim upgrade to {sles} 15 SP7.
+It preserves FIPS-compliant configurations across the migration path.
+To perform the migration, install the updated `suse-migration-services` package on the {sles} 15 SP6 system.
+For more information, see the __Upgrade Guide__.
 
 // bsc#1217826
 [#jsc-PED-8349]


### PR DESCRIPTION
This pull request adds the release notes for direct migration from SLES 15 SP6 to SLES 16.0, bypassing SLES 15 SP7, following PED-14578.