### PR TITLE
SLES 16.1: Add s390x updates for pervasive encryption and z17 (supersedes #126)

### DIFF
--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -17,6 +17,9 @@
       <listitem>
        <para>Added section <link xlink:href="index.html#jsc-PED-14885">Installer support for pervasive encryption on {ibmz}</link> (jsc#PED-14885)</para>
       </listitem>
+      <listitem>
+       <para>Added section <link xlink:href="index.html#jsc-PED-14602">IBM z17 hardware support in libraries and development tools</link> (jsc#PED-14602, jsc#PED-14604, jsc#PED-14610, jsc#PED-14684, jsc#PED-14872)</para>
+      </listitem>
      </itemizedlist>
     </revdescription>
   </revision>

--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-08-26</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Added section <link xlink:href="index.html#jsc-PED-14885">Installer support for pervasive encryption on {ibmz}</link> (jsc#PED-14885)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-08-25</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/sles/release-notes-sles-161.adoc
+++ b/adoc/sles/release-notes-sles-161.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version161.adoc[]
 
 = SUSE Linux Enterprise Server Release Notes
-:revdate: 2026-08-25
+:revdate: 2026-08-26
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -550,6 +550,15 @@ In `s390-tools`, support for 3480 and 3590 FICON tape devices as well as the rel
 Other tape technologies are not affected by this removal.
 Virtual tape servers, such as the emulated IBM TS7700 Virtual Tape Server, continue to be supported via the `tape.ko`, `tape_34xx.ko`, and `tape_3590.ko` kernel modules.
 
+// https://github.com/agama-project/agama/pull/3384
+[#jsc-PED-14885]
+=== Installer support for pervasive encryption on {ibmz}
+
+The Agama installer now supports pervasive encryption (PAES) for storage volumes on {ibmz}.
+The unattended storage JSON profile supports pervasive encryption properties, such as Crypto Express APQNs and key types.
+The storage schema includes the new `apqns` and `keyType` properties under the `pervasiveLuks2` encryption configuration.
+During installation, the encryption planner assigns the specified APQN objects and key types to the planned encrypted devices.
+
 include::../shared.adoc[tag=jscped-15968,leveloffset=+2]
 
 [#power]

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -559,6 +559,17 @@ The unattended storage JSON profile supports pervasive encryption properties, su
 The storage schema includes the new `apqns` and `keyType` properties under the `pervasiveLuks2` encryption configuration.
 During installation, the encryption planner assigns the specified APQN objects and key types to the planned encrypted devices.
 
+// jsc#PED-14604
+// jsc#PED-14610
+// jsc#PED-14684
+// jsc#PED-14872
+[#jsc-PED-14602]
+=== IBM z17 hardware support in libraries and development tools
+
+Several IBM libraries and development tools now support the IBM z17 hardware platform.
+The system libraries `libzdnn`, `libzpc`, and `libica` include updates for the new hardware capabilities.
+Development and debugging tools, such as the GNU C Library (glibc) and Valgrind, also support the new processor instructions.
+
 include::../shared.adoc[tag=jscped-15968,leveloffset=+2]
 
 [#power]


### PR DESCRIPTION
This PR adds the s390x release notes for SLES 16.1, implementing ASD-STE100 and conforming to the style guide. It supersedes and closes #126.

### Changes
- **Note 1 (Installer support for pervasive encryption on {ibmz}):** Document pervasive encryption properties support in the unattended storage JSON profile (jsc#PED-14885).
- **Note 2 (IBM z17 hardware support in libraries and development tools):** Document z17 support in libzdnn, libzpc, libica, glibc, and valgrind (jsc#PED-14602, jsc#PED-14604, jsc#PED-14610, jsc#PED-14684, jsc#PED-14872).
- Updated :revdate: in adoc/sles/release-notes-sles-161.adoc.
- Appended revision entries in adoc/sles/release-notes-sles-161-docinfo.xml.