### PR TITLE
SLES 16.0, SLES 16.1: Document python-bleach deprecation and removal (jsc#PED-16771)

### DIFF
--- a/adoc/sles/release-notes-sles-160-docinfo.xml
+++ b/adoc/sles/release-notes-sles-160-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xml:id="revhistory" xmlns:xlink="http://www.w3.org/1999/xlink">
     <revision>
+     <date>2026-08-27</date>
+     <revdescription>
+      <itemizedlist>
+       <listitem>
+        <para>Documented deprecation of unmaintained python-bleach package (<link xlink:href="index.html#deprecated">jsc#PED-16771</link>)</para>
+       </listitem>
+      </itemizedlist>
+     </revdescription>
+    </revision>
+    <revision>
      <date>2026-08-26</date>
      <revdescription>
       <itemizedlist>

--- a/adoc/sles/release-notes-sles-160.adoc
+++ b/adoc/sles/release-notes-sles-160.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version160.adoc[]
 
 = SUSE Linux Enterprise Server Release Notes
-:revdate: 2026-08-26
+:revdate: 2026-08-27
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -15,6 +15,9 @@
     <revdescription>
      <itemizedlist>
       <listitem>
+       <para>Documented removal of unmaintained python-bleach package (<link xlink:href="index.html#removed">jsc#PED-16771</link>)</para>
+      </listitem>
+      <listitem>
        <para>Added section <link xlink:href="index.html#jsc-PED-16861">Support for Intel "Wildcat Lake-U" CPU platform</link> (jsc#PED-16861)</para>
       </listitem>
      </itemizedlist>

--- a/adoc/sles/version160.adoc
+++ b/adoc/sles/version160.adoc
@@ -1382,6 +1382,13 @@ include::../shared.adoc[tags=jscped12374]
 
 The following features and packages are deprecated and will be removed in a future version of {productname}.
 
+// jsc#PED-16771
+// bsc#1271307
+* The `python-bleach` package is deprecated in {productname} 16.0.
+Upstream does not maintain this package.
+{productname} 16.1 does not include this package.
+To clean HTML, use the `python313-nh3` package.
+
 // bsc#1275537
 * Legacy XFS v4 filesystems are deprecated.
   For details, see <<bsc-1275537>>.

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -722,6 +722,12 @@ This section lists features and packages that were removed from {productname} or
 
 The following features and packages have been removed in this release.
 
+// jsc#PED-16771
+// bsc#1271307
+* The `python-bleach` package is removed from {productname} 16.1.
+Upstream does not maintain this package.
+To clean HTML, use the `python313-nh3` package.
+
 // jsc#PED-16797
 * Due to being no longer maintained, the `ceph` and `thrift` packages have been removed from {ph}.
 


### PR DESCRIPTION
Documents the removal of `python-bleach` from SLES 16.1 and its deprecation in SLES 16.0.

Upstream does not maintain the package. It is already gone from the 16.1 codestream (deleted from `SUSE:SLFO:Main`; no `python-bleach` submodule in `slfo-1.3`, no published binary in `SUSE:SLFO:1.3`). SLES 16.0 still ships `python313-bleach` and cannot drop it, so it is documented as deprecated there instead.

`python313-nh3` is available in both 16.0 and 16.1 and is listed as the replacement.

Refs: jsc#PED-16771, jsc#PED-16776 (RN task), bsc#1271307

Note: the SLES 16.0 note says "deprecated" only. There is still no `python-bleach` entry in `SUSE:SLFO:Products:SLES:16.0/000package-groups/supportstatus.txt`, so calling it unsupported would not yet match the product metadata. That can follow once the supportstatus change lands.

`make validate` passes for `sles_16.0` and `sles_16.1`.