### PR TITLE
CI: Use upstream openSUSE/doc-ci@gha-publish instead of personal branch

### DIFF
--- a/.github/workflows/asciidoc.yml
+++ b/.github/workflows/asciidoc.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Create folder hierarchy for susedoc.github.io
         run: uv run --with pyyaml scripts/build-fleet.py
       - name: Publishing builds on susedoc.github.io
-        uses: openSUSE/doc-ci@lukas-gha-publish-dir
+        uses: openSUSE/doc-ci@gha-publish
         env:
           DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
         with:
@@ -146,7 +146,7 @@ jobs:
       - name: Create folder hierarchy for preview
         run: uv run --with pyyaml scripts/build-fleet.py "preview" "https://susedoc.github.io/release-notes/pr-${{ github.event.pull_request.number }}/sles-16.0/html/release-notes/"
       - name: Publishing preview on susedoc.github.io
-        uses: openSUSE/doc-ci@lukas-gha-publish-dir
+        uses: openSUSE/doc-ci@gha-publish
         env:
           DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ make serve
 `.github/workflows/asciidoc.yml` runs on push/PR when `DC-*` or `adoc/**` changes:
 1. `openSUSE/doc-ci@gha-validate` — validates IDs, images, tables
 2. `openSUSE/doc-ci@gha-build` — builds all DC-* targets
-3. `SUSE/release-notes@gha-publish` — publishes to susedoc.github.io (main branch only)
+3. `openSUSE/doc-ci@gha-publish` — publishes to susedoc.github.io (main branch only)
 
 ## XSLT post-processing
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -69,7 +69,7 @@ make serve
 `.github/workflows/asciidoc.yml` runs on push/PR when `DC-*` or `adoc/**` changes:
 1. `openSUSE/doc-ci@gha-validate` — validates IDs, images, tables
 2. `openSUSE/doc-ci@gha-build` — builds all DC-* targets
-3. `SUSE/release-notes@gha-publish` — publishes to susedoc.github.io (main branch only)
+3. `openSUSE/doc-ci@gha-publish` — publishes to susedoc.github.io (main branch only)
 
 ## XSLT post-processing
 


### PR DESCRIPTION
The publish steps in `asciidoc.yml` pointed at `openSUSE/doc-ci@lukas-gha-publish-dir`, a personal branch used while the `publish-dir` work was in flight.

That work is upstreamed: openSUSE/doc-ci#59 was squash-merged into `gha-publish` on 2026-07-17, and the two branches now have the identical tree SHA `e061e60`. Switching the ref is a behavioural no-op and gets CI off a personal branch.

Also corrects a stale line in `AGENTS.md` and `GEMINI.md`, which described the publish action as `SUSE/release-notes@gha-publish`. Nothing references that branch any more, so it can be retired.