### PR TITLE
SLES 16.1: Add note about curl update to 8.21.0 (jsc#PED-16540)

### DIFF
--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -15,6 +15,9 @@
     <revdescription>
      <itemizedlist>
       <listitem>
+       <para>Added section <link xlink:href="index.html#jsc-PED-16540">curl updated to version 8.21.0</link> (jsc#PED-16540)</para>
+      </listitem>
+      <listitem>
        <para>Documented removal of unmaintained python-bleach package (<link xlink:href="index.html#removed">jsc#PED-16771</link>)</para>
       </listitem>
       <listitem>

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -274,6 +274,12 @@ include::../shared.adoc[tags=bsc1275537,leveloffset=+2]
 Compatibility for SDL 2.0 applications is now provided through the `sdl2-compat` library layer.
 The legacy `SDL2` package has been removed.
 
+[#jsc-PED-16540]
+=== `curl` updated to version 8.21.0
+
+{productname} {this-version} includes `curl` version 8.21.0.
+For a complete list of changes, see the link:https://curl.se/ch/8.21.0.html[curl 8.21.0 changelog].
+
 [#jsc-PED-16669-upcoming]
 === Upcoming update of GNU `patch` to version 2.8 in {productname} 16.2
 


### PR DESCRIPTION
Documents the update of `curl` to version 8.21.0 in SLES 16.1.

The update has landed in the 16.1 codestream: `SUSE:SLFO:1.3` carries `curl` 8.21.0 (`curl.spec` `Version: 8.21.0`, r1 on 2026-08-18) after https://src.suse.de/pool/curl/pulls/20 was merged to `slfo-main`. SLES 16.0 stays on 8.14.1.

The note goes into `adoc/sles/version161.adoc`, which SLES for SAP 16.1 and openSUSE Leap 16.1 also include, so it appears in those documents too. That matches how the neighbouring package notes behave, and both products are built from `SUSE:SLFO:1.3`, so 8.21.0 is correct for them. SLE HA 16.1 has its own `version161.adoc` and is not affected.

Of the remaining SLFO products, only `SLES_NVIDIA:16.1`, `BCI:16.1` and `WSL:16.1` pick up 8.21.0, and none of them has its own release notes. SL Micro 6.2 and Multi-Linux-Manager 5.2 build from `SUSE:SLFO:1.2` and keep 8.14.1, so there is no SL Micro note despite the epic listing that component.

The note states the target version and links the upstream changelog. The 8.20.0/8.21.0 jump carries 18 CVE fixes; those are left to the changelog rather than enumerated.

Refs: jsc#PED-16540, jsc#PED-16651 (RN task)

`make validate PRODUCT_VERSION=sles_16.1` passes.