### PR TITLE
CI: Compare against merge base when detecting affected DC files

### DIFF
--- a/.github/workflows/asciidoc.yml
+++ b/.github/workflows/asciidoc.yml
@@ -32,19 +32,26 @@ jobs:
       - name: Detect affected DC files
         id: set-output
         run: |
+          # For pull requests, DIFF_RANGE uses "..." so that the comparison is
+          # against the merge base. A two-dot diff against base.sha also reports
+          # everything the base branch gained since the PR branched off, which
+          # can wrongly trigger the build-everything fallback in
+          # detect-affected-dcs.py.
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             BASE_SHA="${{ github.event.pull_request.base.sha }}"
             HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+            DIFF_RANGE="$BASE_SHA...$HEAD_SHA"
           else
             BASE_SHA="${{ github.event.before }}"
             HEAD_SHA="${{ github.event.after }}"
             if [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ] || [ -z "$BASE_SHA" ] || ! git cat-file -e "$BASE_SHA" >/dev/null 2>&1; then
               BASE_SHA="HEAD^"
             fi
+            DIFF_RANGE="$BASE_SHA $HEAD_SHA"
           fi
-          
-          echo "Comparing $BASE_SHA to $HEAD_SHA"
-          CHANGED_FILES=$(git diff --name-only $BASE_SHA $HEAD_SHA)
+
+          echo "Comparing $DIFF_RANGE"
+          CHANGED_FILES=$(git diff --name-only $DIFF_RANGE)
           
           AFFECTED=$(echo "$CHANGED_FILES" | uv run scripts/detect-affected-dcs.py)
           echo "Affected DC files: $AFFECTED"


### PR DESCRIPTION
The `detect` job compared `pull_request.base.sha` to `pull_request.head.sha` with a two-dot `git diff`. `base.sha` is the current tip of the base branch, not the merge base, so the diff also reported every file that `main` gained after the PR branched off.

`scripts/detect-affected-dcs.py` treats any path outside `adoc/` and `DC-*` as a global trigger and falls back to printing all DC files. So as soon as an unrelated commit touching `.github/`, `scripts/` or `Makefile` landed on `main`, every open PR started building all 56 documents.

This happened on #134, which changes two files under `adoc/sles/`:

```
Comparing 535b72a to 1e2cece
Affected DC files: DC-releasenotes_leap_16.0 DC-releasenotes_leap_16.1 ... (all 56)
```

`535b72a` is the merge of #133, which landed on `main` after #134 branched off and touches `.github/workflows/asciidoc.yml`.

Using `$BASE_SHA...$HEAD_SHA` diffs against the merge base instead. For the same two commits:

```
$ git diff --name-only 535b72a 1e2cece | python3 scripts/detect-affected-dcs.py | wc -w
56
$ git diff --name-only 535b72a...1e2cece | python3 scripts/detect-affected-dcs.py
DC-releasenotes_leap_16.1 DC-releasenotes_sles-sap_16.1 DC-releasenotes_sles_16.1
```

No coverage is lost. A three-dot diff still reports every commit on the PR branch, not only the most recent push. The only case it drops is a file changed and then reverted within the same PR, which is correct because the file ends up identical to the base branch.

The `push` branch keeps the two-dot form, which is correct there: `event.before` really is the previous tip of the same branch.