### PR TITLE
SLES 16.0, SLES 16.1: Add note about libzpc 2 and the zpckey tool (jsc#PED-15050)

### DIFF
--- a/adoc/shared.adoc
+++ b/adoc/shared.adoc
@@ -434,4 +434,20 @@ To get the image, use the path `registry.suse.com/suse/sles-{this-version}-kubev
 
 end::jscped-14582[]
 
+tag::jscped-15050[]
+[#jsc-PED-15050]
+= New `zpckey` tool and changed interface in `libzpc` 2
 
+{productname} includes `libzpc` version 2 for {ibmz}.
+
+The new `libzpc-tools` package provides the `zpckey` tool.
+Use `zpckey` to create and manage protected key origins, such as Secure Execution retrievable secrets.
+`zpckey` writes each key origin to a file.
+The OpenSSL provider module in the `libzpc-provider` package then reads the file.
+For more information, see the `zpckey(1)` man page.
+
+Version 2 does not provide the `libzpc` C API as a shared library.
+Applications must use the OpenSSL provider module instead.
+The `libzpc-legacy` package provides the version 1 packages `libzpc1` and `libzpc-devel`.
+This package is deprecated and will be removed in a future release.
+end::jscped-15050[]

--- a/adoc/sles/release-notes-sles-160-docinfo.xml
+++ b/adoc/sles/release-notes-sles-160-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xml:id="revhistory" xmlns:xlink="http://www.w3.org/1999/xlink">
     <revision>
+     <date>2026-08-28</date>
+     <revdescription>
+      <itemizedlist>
+       <listitem>
+        <para>Added section <link xlink:href="index.html#jsc-PED-15050">New <literal>zpckey</literal> tool and changed interface in <literal>libzpc</literal> 2</link> (jsc#PED-15050)</para>
+       </listitem>
+      </itemizedlist>
+     </revdescription>
+    </revision>
+    <revision>
      <date>2026-08-27</date>
      <revdescription>
       <itemizedlist>

--- a/adoc/sles/release-notes-sles-160.adoc
+++ b/adoc/sles/release-notes-sles-160.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version160.adoc[]
 
 = SUSE Linux Enterprise Server Release Notes
-:revdate: 2026-08-27
+:revdate: 2026-08-28
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -15,6 +15,9 @@
     <revdescription>
      <itemizedlist>
       <listitem>
+       <para>Added section <link xlink:href="index.html#jsc-PED-15050">New <literal>zpckey</literal> tool and changed interface in <literal>libzpc</literal> 2</link> (jsc#PED-15050)</para>
+      </listitem>
+      <listitem>
        <para>Added section <link xlink:href="index.html#jsc-PED-14582">{productname} containerdisk image now available</link> (jsc#PED-14582)</para>
       </listitem>
      </itemizedlist>

--- a/adoc/sles/release-notes-sles-161.adoc
+++ b/adoc/sles/release-notes-sles-161.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version161.adoc[]
 
 = SUSE Linux Enterprise Server Release Notes
-:revdate: 2026-08-27
+:revdate: 2026-08-28
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/sles/version160.adoc
+++ b/adoc/sles/version160.adoc
@@ -944,6 +944,11 @@ For more information, see https://www.ibm.com/docs/en/linux-on-systems?topic=dis
 
 === Security
 
+// jsc#PED-15051
+// jsc#PED-16483
+// jsc#PED-16488
+include::../shared.adoc[tags=jscped-15050,leveloffset=+3]
+
 [#jsc-PED-15721]
 ==== Support for MS SQL Server 2025 legacy hashing algorithms in OpenSSL 3
 

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -556,6 +556,11 @@ which have undergone compatibility testing.
 Information in this section applies to {z-productname}.
 For more information, see https://www.ibm.com/docs/en/linux-on-systems?topic=distributions-suse-linux-enterprise-server
 
+// jsc#PED-15051
+// jsc#PED-16483
+// jsc#PED-16488
+include::../shared.adoc[tags=jscped-15050,leveloffset=+2]
+
 // jsc#PED-13734
 // bsc#1249961
 [#jsc-PED-15030]


### PR DESCRIPTION
Adds a shared release note for the `libzpc` 2 update on IBM Z, covering the new `zpckey` tool and the removal of the C library interface.

Included in SLES 16.1 (top of the IBM Z section) and SLES 16.0 (top of the IBM Z Security section), and consequently also in SLES for SAP 16.0/16.1.

Sources: jsc#PED-15050 (epic), jsc#PED-15051 (impl), jsc#PED-16483 (ECO), jsc#PED-16488 (RN task).

Note: the wording follows the ECO comment of 2026-08-25 — `libzpc` 2.x plus a `libzpc-legacy` transition package for both 16.0 and 16.1. In OBS today only SLFO:1.3 carries `libzpc` 2.0.1, and `libzpc-legacy` is not yet in either product compose.

`make validate` passes for `sles_16.0`, `sles_16.1`, `sles-sap_16.0`, and `sles-sap_16.1`.