### PR TITLE
SLES 16.1: Add note about vPMEM support in virtual machine guests (jsc#PED-16345)

### DIFF
--- a/adoc/common/attributes-generic.adoc
+++ b/adoc/common/attributes-generic.adoc
@@ -332,6 +332,14 @@
 :huaweireg:                  {huawei}{thrdmrk}
 :kunpeng:                    Kunpeng
 :kunpengreg:                 {kunpeng}{thrdmrk}
+// Added downstream ahead of the doc-kit rollout, see openSUSE/doc-kit#135:
+// https://www.intel.com/content/www/us/en/legal/trademarks.html
+:intel:                      Intel
+:intelreg:                   {intel}{thrdmrk}
+:optane:                     {intel}{nbsp}Optane
+:optanereg:                  {intelreg}{nbsp}Optane{thrdmrk}
+:optanemem:                  {optane} Memory
+:optanememreg:               {optanereg} Memory
 // Khronos
 :openmax:                    OpenMAX
 :openmaxreg:                 {openmax}{thrdmrk}

--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -15,6 +15,9 @@
     <revdescription>
      <itemizedlist>
       <listitem>
+       <para>Added section <link xlink:href="index.html#jsc-PED-16345">Virtual persistent memory (vPMEM) in virtual machine guests</link> (jsc#PED-16345)</para>
+      </listitem>
+      <listitem>
        <para>Added section <link xlink:href="index.html#jsc-PED-15050">New <literal>zpckey</literal> tool and changed interface in <literal>libzpc</literal> 2</link> (jsc#PED-15050)</para>
       </listitem>
       <listitem>

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -643,6 +643,14 @@ Automated initial guest provisioning is now fully supported.
 * iSCSI boot support is disabled in OVMF images.
 
 
+[#jsc-PED-16345]
+=== Virtual persistent memory (vPMEM) in virtual machine guests
+
+{productname} {this-version} supports virtual persistent memory (vPMEM) in virtual machine guests on {x64} and {ppc64le}.
+The guest kernel detects the vPMEM regions and loads the applicable driver without manual configuration.
+{productname} does not support physical {optanememreg}.
+
+
 [#jsc-PED-14599]
 === QEMU
 


### PR DESCRIPTION
Adds a release note for SLES 16.1 stating that vPMEM is supported in virtual machine guests (jsc#PED-16345).

The feature is tracked in PED-16329 (Code Released) / PED-16344 (Testing in QE). The enablement landed through kernel-source [pool/kernel-source#61](https://src.suse.de/pool/kernel-source/pulls/61) and the follow-up crash bsc#1266323 is VERIFIED/FIXED for 16.1. Per the discussion on PED-16344, vPMEM was most likely never actually disabled, so this note mainly clarifies support status against the existing statement that Intel Optane is not supported.

The note is placed at the top of the Virtualization section and rendered as:

> **Virtual persistent memory (vPMEM) in virtual machine guests**
>
> SUSE Linux Enterprise Server 16.1 supports virtual persistent memory (vPMEM) in virtual machine guests on x86-64 and ppc64le.
> The guest kernel detects the vPMEM regions and loads the applicable driver without manual configuration.
> SUSE Linux Enterprise Server does not support physical Intel\* Optane\* Memory.

The first commit adds `intel`/`optane` attributes to `adoc/common/attributes-generic.adoc`. That file is upstream-managed by doc-kit, so the addition is temporary and will be overwritten by the next doc-kit update; the same attributes are proposed upstream in openSUSE/doc-kit#135.

`make validate` passes for `sles_16.1` and `sles_16.0`.

Only 16.1 is covered. PED-16344 also lists 16.0 and 16.2 as fix versions, but there is no matching 16.0 kernel change and the bug is filed against 16.1 Beta2; 16.2 inherits from 16.1.
