### PR TITLE
SLES 16.1: Add Rockchip RK3588 to Arm SoC driver enablement (jsc#PED-16288)

### DIFF
--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -527,7 +527,8 @@ System-on-Chip (SoC) chipsets:
 // jsc#SLE-12251 (LS1012A), jsc#SLE-11914 (i.MX 8MM)
 * {nxpreg} {imx} 8M, 8M{nbsp}Mini; {layerscapereg} LS1012A, LS1027A/LS1017A, LS1028A/LS1018A, LS1043A, LS1046A, LS1088A, LS2080A/LS2040A, LS2088A, LX2160A
 // * {qcomreg} {centriqreg} 2400
-* Rockchip RK3399
+// jsc#PED-16288 (RK3588)
+* Rockchip RK3399, RK3588
 * {socionextreg} {synquacerreg} SC2A11
 * {xilinxreg} {zynqreg} {ultrascalereg}{nbzwsp}+ MPSoC
 


### PR DESCRIPTION
Adds Rockchip RK3588 to the aarch64 System-on-Chip driver enablement list for SLES 16.1.

Source: `kernel-source` `slfo-1.3` marks 12 modules as supported in `supported.conf` (commit `b59e310`, 2026-06-12, duwe@suse.de — "supported.conf: support rk3588-based SBCs (jsc#PED-16288)"): `rockchip-rng`, `gpio-rockchip`, `rockchip_saradc`, `rk805-pwrkey`, `rk8xx-core`/`-i2c`/`-spi`, `rtc-hym8563`, `spi-rockchip`, `spi-rockchip-sfc`, `rockchip_thermal`, `pl330`. Not present in `slfo-1.2` (16.0).

RK3576 is intentionally omitted: the RN task title names it, but no implementation issue or `supported.conf` change covers it. Pending confirmation on PED-13145; a follow-up is a one-word edit.

Jira: https://jira.suse.com/browse/PED-16289