### PR TITLE
SLES 16.1: Add note about strace upgrade to version 7.1 (jsc#PED-16244)

### DIFF
--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -15,6 +15,9 @@
     <revdescription>
      <itemizedlist>
       <listitem>
+       <para>Added section <link xlink:href="index.html#jsc-PED-16244">strace updated to version 7.1</link> (jsc#PED-16244)</para>
+      </listitem>
+      <listitem>
        <para>Added section <link xlink:href="index.html#jsc-PED-16260">Characters in the private use area disabled in the alternate German keymap</link> (jsc#PED-16260)</para>
       </listitem>
      </itemizedlist>

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -735,6 +735,22 @@ Important considerations:
 * The script must be run locally (not over a remote connection) immediately after installation and before applying any custom network configurations.
 
 
+[#jsc-PED-16244]
+==== `strace` updated to version 7.1
+
+`strace` has been updated to version 7.1.
+
+This update includes the following changes:
+
+* The summary report (`-c` or `--summary-only`) now supports wall-clock-aware columns (`wall-total`, `wall-min`, `wall-max`, and `wall-avg`).
+This allows comparison of wall-clock and system CPU times in a single run.
+* The summary report now includes out-of-range system calls.
+* This update improves decoding of the `sched_getattr` system call.
+* The utility now decodes the `FS_IOC_SHUTDOWN`, `PIDFD_GET_INFO`, and `PIDFD_GET_*_NAMESPACE` ioctl commands.
+* The utility now decodes the `IFLA_BR_FDB_N_LEARNED`, `IFLA_BR_FDB_MAX_LEARNED`, and `IFLA_BR_STP_MODE` netlink attributes.
+* This version updates the system call constant lists for `CLONE_*`, `FSMOUNT_*`, `KT_*`, `KVM_*`, `LANDLOCK_*`, `NETDEV_*`, `NL80211_*`, and `PIDFD_*`.
+* This version adds support for Linux kernel 7.1 ioctl commands.
+
 
 [#removed-deprecated]
 == Removed and deprecated features and packages


### PR DESCRIPTION
This pull request documents the upgrade of `strace` to version 7.1 for SLES 16.1 (jsc#PED-16244).

It adds a new subsection under `=== Other tools` in `adoc/sles/version161.adoc` detailing the wall-clock-aware columns for summary reports, updated system call decoding, and support for Linux kernel 7.1 ioctl commands. All changes conform to SUSE writing style guidelines (including Simplified Technical English and one sentence per line).