### PR TITLE
SLES 16.1: Add note about PHP 8.5 update (jsc#PED-16238)

### DIFF
--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -15,6 +15,9 @@
     <revdescription>
      <itemizedlist>
       <listitem>
+       <para>Added section <link xlink:href="index.html#jsc-PED-16238">PHP updated to version 8.5</link> (jsc#PED-16238)</para>
+      </listitem>
+      <listitem>
        <para>Added section <link xlink:href="index.html#jsc-PED-16244">strace updated to version 7.1</link> (jsc#PED-16244)</para>
       </listitem>
       <listitem>

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -290,6 +290,12 @@ The legacy `SDL2` package has been removed.
 {productname} {this-version} includes `curl` version 8.21.0.
 For a complete list of changes, see the link:https://curl.se/ch/8.21.0.html[curl 8.21.0 changelog].
 
+[#jsc-PED-16238]
+=== PHP updated to version 8.5
+
+{productname} {this-version} includes PHP version 8.5.
+For more information, see the link:https://www.php.net/releases/8_5_0.php[PHP 8.5 release announcement] and the link:https://documentation.suse.com/sles/16.0/html/SLE-packages-lifecycle/index.html#packages-lifecycle-php[PHP Packages Lifecycle documentation].
+
 [#jsc-PED-16669-upcoming]
 === Upcoming update of GNU `patch` to version 2.8 in {productname} 16.2
 


### PR DESCRIPTION
This PR adds a release note section for the PHP 8.5 update in SLES 16.1 under version161.adoc, along with the corresponding changelog and revdate updates. Resolves: jsc#PED-16238