### PR TITLE
SLES 16.1: Add release note for poppler update to 26.x (jsc#PED-16203)

### DIFF
--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -15,6 +15,9 @@
     <revdescription>
      <itemizedlist>
       <listitem>
+       <para>Added section <link xlink:href="index.html#jsc-PED-16203">poppler updated to version 26.x</link> (jsc#PED-16203)</para>
+      </listitem>
+      <listitem>
        <para>Added section <link xlink:href="index.html#jsc-PED-16216">Performance Co-Pilot (PCP) upgraded to version 6.3.8</link> (jsc#PED-16216)</para>
       </listitem>
       <listitem>

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -311,6 +311,15 @@ For more information, see the link:https://www.php.net/releases/8_5_0.php[PHP 8.
 
 {productname} {this-version} includes the `poppler` PDF rendering library version 26.x.
 
+This version update introduces several important changes for system administrators:
+
+* **Removal of piped output filenames:** For security reasons, passing a piped command as a filename parameter (for example, `| command`) is no longer supported in `pdftops`.
+Use standard shell pipelines instead.
+* **`pdfsig` exit codes:** The `pdfsig` utility now returns a non-zero exit code on signature validation failure.
+This may affect automated verification scripts.
+* **`pdftotext` line endings:** The `pdftotext` tool now defaults to `\n` line endings.
+* **New signature features:** The `pdfsig` utility includes a new `--assert-signer` option to verify the identity of the signer.
+
 [#jsc-PED-16669-upcoming]
 === Upcoming update of GNU `patch` to version 2.8 in {productname} 16.2
 

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -306,6 +306,11 @@ For a complete list of changes, see the link:https://curl.se/ch/8.21.0.html[curl
 {productname} {this-version} includes PHP version 8.5.
 For more information, see the link:https://www.php.net/releases/8_5_0.php[PHP 8.5 release announcement] and the link:https://documentation.suse.com/sles/16.0/html/SLE-packages-lifecycle/index.html#packages-lifecycle-php[PHP Packages Lifecycle documentation].
 
+[#jsc-PED-16203]
+=== `poppler` updated to version 26.x
+
+{productname} {this-version} includes the `poppler` PDF rendering library version 26.x.
+
 [#jsc-PED-16669-upcoming]
 === Upcoming update of GNU `patch` to version 2.8 in {productname} 16.2
 


### PR DESCRIPTION
Drafts the release note for the poppler update to 26.x in SLES 16.1. Linked to Jira PED-16203.