### PR TITLE
SLES 16.1: Add note about Network UPS Tools (NUT) version 2.8.5 (jsc#PED-16187)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build/
 bugreports/
 *.code-workspace
 .worktrees/
+.superpowers/

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -189,6 +189,15 @@ include::../shared.adoc[tags=jscped-5576,leveloffset=+2]
 // jsc#PED-14582
 include::../shared.adoc[tags=jscped-14582,leveloffset=+2]
 
+// bsc#1270050
+[#jsc-PED-16187]
+=== Network UPS Tools (NUT) updated to version 2.8.5
+
+{productname} {this-version} updates Network UPS Tools (NUT) to version 2.8.5.
+This version upgrade introduces new hardware drivers, STARTTLS handling improvements, and support for name aliasing.
+A security patch resolves CVE-2026-54161, which prevented a potential remote command injection vulnerability in `NOTIFYCMD`.
+For a complete list of changes, see the upstream release notes.
+
 [#jsc-PED-14654]
 === Linux kernel BPF subsystem updated to match upstream v6.13 to v6.18
 


### PR DESCRIPTION
Upgrade NUT to version 2.8.5 (Jira: PED-16187, bsc#1270050)