### PR TITLE
SLES 16.1: Add release note for atomic console support on ARM64 (jsc#PED-16033)

### DIFF
--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -15,6 +15,9 @@
     <revdescription>
      <itemizedlist>
       <listitem>
+       <para>Added section <link xlink:href="index.html#jsc-PED-16033">Non-blocking console support for ARM64 (aarch64)</link> (jsc#PED-16033)</para>
+      </listitem>
+      <listitem>
        <para>Added section <link xlink:href="index.html#jsc-PED-16203">poppler updated to version 26.x</link> (jsc#PED-16203)</para>
       </listitem>
       <listitem>

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -555,6 +555,14 @@ Additionally, this release enables Intel Platform Monitoring Technology (PMT) fe
 [#aarch64]
 == {arm}-specific changes ({aarch64})
 
+[#jsc-PED-16033]
+=== Non-blocking console support for ARM64 (aarch64)
+
+Non-blocking console (`nbcon`) support is enabled on the {aarch64} architecture.
+The common AMBA PL011 serial console driver (`amba-pl011`) is converted to the new `nbcon` API.
+This allows the kernel to log messages atomically and reliably to the console even from non-maskable interrupt (NMI) contexts (such as during an `nmi_panic`).
+This ensures critical post-crash details are captured immediately without relying on legacy printing locks or threads.
+
 [#arm64-soc]
 === System-on-Chip driver enablement
 


### PR DESCRIPTION
This PR implements the SLES 16.1 release note for atomic console support on ARM64 (PED-16033). The changes have been validated locally using `make validate` and build successfully.