### PR TITLE
SLES 16.1: Document default p11-kit-nss-trust store for mozilla-nss (jsc#PED-15634)

### DIFF
--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -15,6 +15,9 @@
     <revdescription>
      <itemizedlist>
       <listitem>
+       <para>Documented default installation of <literal>p11-kit-nss-trust</literal> over <literal>mozilla-nss-certs</literal> in <literal>mozilla-nss</literal> (<link xlink:href="index.html#jsc-PED-15634">jsc#PED-15634</link>)</para>
+      </listitem>
+      <listitem>
        <para>Added section <link xlink:href="index.html#jsc-PED-16203">poppler updated to version 26.x</link> (jsc#PED-16203)</para>
       </listitem>
       <listitem>

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -189,6 +189,17 @@ include::../shared.adoc[tags=jscped-5576,leveloffset=+2]
 // jsc#PED-14582
 include::../shared.adoc[tags=jscped-14582,leveloffset=+2]
 
+[#jsc-PED-15634]
+=== `mozilla-nss` favors `p11-kit-nss-trust` over `mozilla-nss-certs` by default
+
+New installations of `mozilla-nss` now install `p11-kit-nss-trust` by default to provide `libnssckbi.so`.
+This change replaces the default installation of `mozilla-nss-certs`.
+The `p11-kit-nss-trust` package allows central configuration of system-wide root certificates.
+Firefox and other NSS consumers automatically inherit these central certificates.
+This avoids manual importing of enterprise certificates into individual profiles.
+Existing installations maintain their configuration during system upgrades.
+NSS static certificates remain available via the `mozilla-nss-certs` package and can be installed manually if required.
+
 // bsc#1270050
 [#jsc-PED-16187]
 === Network UPS Tools (NUT) updated to version 2.8.5


### PR DESCRIPTION
This PR adds the release note for PED-15634 under SLES 16.1.

Summary of changes:
- By default, new installations of the `mozilla-nss` package now pull in `p11-kit-nss-trust` as the provider of `libnssckbi.so`, replacing the static `mozilla-nss-certs` list.
- This allows system-wide "enterprise root certificates" (such as the SUSE Trust Root) to be centrally installed and automatically utilized by Firefox and other consumers, avoiding the need for users to manually configure security exceptions or explicitly import certificates for every user profile.
- Adds appropriate changelog entry in the docinfo.xml revision block.