### PR TITLE
SLES 16.1: Add note about real-time kernel availability (jsc#PED-15432)

### DIFF
--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -15,6 +15,9 @@
     <revdescription>
      <itemizedlist>
       <listitem>
+       <para>Added section <link xlink:href="index.html#jsc-PED-15432">Real-time kernel is available on standard {productname} installations</link> (jsc#PED-15432)</para>
+      </listitem>
+      <listitem>
        <para>Added section <link xlink:href="index.html#jsc-PED-14671">Python in SLES 16.1</link> (jsc#PED-14671)</para>
       </listitem>
       <listitem>

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -446,6 +446,15 @@ The `PREEMPT_LAZY` model provides a less conservative approach to preemption, wh
 If you experience performance issues with the new preemption model, you can optionally switch back to `PREEMPT_VOLUNTARY` by setting `preempt=voluntary` on the kernel command line.
 
 
+[#jsc-PED-15432]
+=== Real-time kernel is available on standard {productname} installations
+
+Standard {productname} installations now include the real-time kernel (`kernel-rt`).
+Previously, the real-time kernel was only available on systems with the Transactional Server role.
+All system roles now support the real-time kernel.
+This change provides deterministic latency and predictable execution times for standard server installations.
+
+
 [#bsc-1261338]
 === RAID configuration not supported in installer Web UI
 


### PR DESCRIPTION
Add SLES 16.1 release note documenting the availability of the real-time kernel (`kernel-rt`) on standard installations.