### PR TITLE
SLES 16.1: Update FreeRDP to version 3.26.0 (jsc#PED-15573)

### DIFF
--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -15,6 +15,9 @@
     <revdescription>
      <itemizedlist>
       <listitem>
+       <para>Added section <link xlink:href="index.html#jsc-PED-15573">FreeRDP has been updated to version 3.26.0</link> (jsc#PED-15573)</para>
+      </listitem>
+      <listitem>
        <para>Added section <link xlink:href="index.html#jsc-PED-15432">Real-time kernel is available on standard {productname} installations</link> (jsc#PED-15432)</para>
       </listitem>
       <listitem>

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -307,6 +307,12 @@ Configurations that rely on custom characters mapped to this range require manua
 Compatibility for SDL 2.0 applications is now provided through the `sdl2-compat` library layer.
 The legacy `SDL2` package has been removed.
 
+[#jsc-PED-15573]
+=== FreeRDP has been updated to version 3.26.0
+
+FreeRDP has been updated to version 3.26.0.
+This update introduces support for FIDO2 redirection ([MS-RDPEWA]), experimental AV1 codec extension, and performance improvements for SDL3 client drawing.
+
 // jsc#PED-16216
 [#jsc-PED-16216]
 === Performance Co-Pilot (PCP) upgraded to version 6.3.8


### PR DESCRIPTION
This PR adds the release note for FreeRDP 3.26.0 update in SLES 16.1 under PED-15573.