### PR TITLE
SLES 16.1, SLE HA 16.1: Move haproxy and keepalived to SLES (jsc#PED-15496)

### DIFF
--- a/adoc/shared.adoc
+++ b/adoc/shared.adoc
@@ -462,3 +462,13 @@ Only the Base image variant remains available.
 Additionally, on the {power} architecture ({ppc64le}), this release removes the pre-built images for 512-byte sector sizes.
 Only images for 4096-byte (4 kB) sector sizes are now provided for {ppc64le}.
 end::jscped-15447[]
+
+tag::jscped-15496[]
+[#jsc-PED-15496]
+= `{haproxy}` and `{keepalived}` moved to `{sles}`
+
+Previously, only the `{sleha}` extension included `{haproxy}` and `{keepalived}`.
+The base `{sles}` distribution now includes both `{haproxy}` and `{keepalived}`.
+This change makes these packages available on standard installations without a separate High Availability subscription.
+end::jscped-15496[]
+

--- a/adoc/sleha/release-notes-sleha-161-docinfo.xml
+++ b/adoc/sleha/release-notes-sleha-161-docinfo.xml
@@ -15,6 +15,9 @@
     <revdescription>
      <itemizedlist>
       <listitem>
+       <para>Documented that haproxy and keepalived moved to SLES (<link xlink:href="index.html#jsc-PED-15496">jsc#PED-15496</link>)</para>
+      </listitem>
+      <listitem>
        <para>Added SBD parameter validation with `crm cluster health sbd` (<link xlink:href="index.html#jsc-PED-14996">jsc#PED-14996</link>)</para>
       </listitem>
      </itemizedlist>

--- a/adoc/sleha/version161.adoc
+++ b/adoc/sleha/version161.adoc
@@ -24,6 +24,9 @@ Installation media, VM images and public cloud images are usually refreshed ever
 
 === Changes affecting all architectures
 
+// jsc#PED-15496
+include::../shared.adoc[tags=jscped-15496,leveloffset=+3]
+
 [#jsc-PED-14996]
 ==== SBD parameter validation with `crm cluster health sbd`
 

--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -15,6 +15,9 @@
     <revdescription>
      <itemizedlist>
       <listitem>
+       <para>Added section <link xlink:href="index.html#jsc-PED-15496">haproxy and keepalived moved to SLES</link> (jsc#PED-15496)</para>
+      </listitem>
+      <listitem>
        <para>Added section <link xlink:href="index.html#jsc-PED-15432">Real-time kernel is available on standard {productname} installations</link> (jsc#PED-15432)</para>
       </listitem>
       <listitem>

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -183,6 +183,9 @@ Before upgrading to {productname} {this-version}, review the following checklist
 // jsc#PED-12658
 * `rasdaemon` has been updated to version 0.8.4. This version supports machine checks related to CXL memory. Since Intel® Optane™ Memory products have reached End of Life (EOL), {productname} {this-version} does not support them either.
 
+// jsc#PED-15496
+include::../shared.adoc[tags=jscped-15496,leveloffset=+2]
+
 // jsc#PED-5576
 include::../shared.adoc[tags=jscped-5576,leveloffset=+2]
 


### PR DESCRIPTION
This pull request documents the migration of haproxy and keepalived packages from the High Availability extension to the base SLES distribution starting with version 16.1.