### PR TITLE
SLES 16.1, SLE Micro 6.3: Document removal of Elemental 2.x (jsc#PED-15396)

### DIFF
--- a/adoc/micro/release-notes-micro-63-docinfo.xml
+++ b/adoc/micro/release-notes-micro-63-docinfo.xml
@@ -9,9 +9,16 @@
 <productname>{productname}</productname>
 <productnumber>{this-version}</productnumber>
 <date>{revdate}</date>
-<revhistory>
+<revhistory xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
-    <date>{revdate}</date>
+    <date>2026-09-02</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Added section <link xlink:href="index.html#jsc-PED-15396">Support for {ranchelemental} 2.x removed</link> (jsc#PED-15396)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
   </revision>
 </revhistory>
 <meta name="series">Release Notes</meta>

--- a/adoc/micro/release-notes-micro-63.adoc
+++ b/adoc/micro/release-notes-micro-63.adoc
@@ -4,7 +4,7 @@ include::attributes.adoc[]
 :this-version: 6.3
 
 = SL Micro Release Notes
-:revdate: 2025-09-04
+:revdate: 2026-09-02
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/micro/version63.adoc
+++ b/adoc/micro/version63.adoc
@@ -10,6 +10,8 @@ These release notes apply to {productname} {this-version}.
 
 === Changes affecting all architectures
 
+include::../shared.adoc[tags=jscped-15396,leveloffset=+3]
+
 // SHA1 disabled
 include::../shared.adoc[tags=jscped-12210,leveloffset=+3]
 

--- a/adoc/shared.adoc
+++ b/adoc/shared.adoc
@@ -472,3 +472,12 @@ The base `{sles}` distribution now includes both `{haproxy}` and `{keepalived}`.
 This change makes these packages available on standard installations without a separate High Availability subscription.
 end::jscped-15496[]
 
+tag::jscped-15396[]
+[#jsc-PED-15396]
+= Support for {ranchelemental} 2.x removed
+
+This release removes {ranchelemental} 2.x components and container images.
+To manage operating system deployments, use {ranchelemental} 3.x.
+The coexistence of versions 2.x and 3.x in the previous release supported the migration path.
+Only {ranchelemental} 3.x remains supported from this release onward.
+end::jscped-15396[]

--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -15,6 +15,9 @@
     <revdescription>
      <itemizedlist>
       <listitem>
+       <para>Added section <link xlink:href="index.html#jsc-PED-15396">Support for {ranchelemental} 2.x removed</link> (jsc#PED-15396)</para>
+      </listitem>
+      <listitem>
        <para>Added section <link xlink:href="index.html#jsc-PED-15496">haproxy and keepalived moved to SLES</link> (jsc#PED-15496)</para>
       </listitem>
       <listitem>

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -901,6 +901,8 @@ To clean HTML, use the `python313-nh3` package.
 * The UDP-Lite protocol (RFC 3828) has been disabled in the {productname} 16.1 kernel.
   This protocol has been dropped from the upstream Linux kernel.
 
+include::../shared.adoc[tags=jscped-15396,leveloffset=+3]
+
 
 [#deprecated]
 === Deprecated features and packages


### PR DESCRIPTION
Documents the removal of Elemental 2.x components and container images from SLES 16.1 and SLE Micro 6.3 under the task PED-15396.