### PR TITLE
SLES 16.1, SLES for SAP 16.1: Add note about increased installer boot menu timeout (jsc#PED-15000)

### DIFF
--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -15,6 +15,9 @@
     <revdescription>
      <itemizedlist>
       <listitem>
+       <para>Added section <link xlink:href="index.html#jsc-PED-15000">Increased timeout for installer boot menu</link> (jsc#PED-15000)</para>
+      </listitem>
+      <listitem>
        <para>Added section <link xlink:href="index.html#jsc-PED-15396">Support for {ranchelemental} 2.x removed</link> (jsc#PED-15396)</para>
       </listitem>
       <listitem>

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -192,6 +192,14 @@ include::../shared.adoc[tags=jscped-5576,leveloffset=+2]
 // jsc#PED-14582
 include::../shared.adoc[tags=jscped-14582,leveloffset=+2]
 
+[#jsc-PED-15000]
+=== Increased timeout for installer boot menu
+
+The boot menu of the live installation medium now has a timeout of 60 seconds.
+Previously, the timeout was ten seconds.
+This change provides more time to select options from the boot menu.
+This change does not affect the boot timeout of the installed system.
+
 [#jsc-PED-15634]
 === `mozilla-nss` favors `p11-kit-nss-trust` over `mozilla-nss-certs` by default
 


### PR DESCRIPTION
Add release note for PED-15000 regarding the increased installer boot menu timeout.