### PR TITLE
SLES 16.1: Document task-based CPU throttling to prevent lock delays (jsc#PED-14959)

### DIFF
--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -15,6 +15,9 @@
     <revdescription>
      <itemizedlist>
       <listitem>
+       <para>Added section <link xlink:href="index.html#jsc-PED-14959">Reduced kernel lock delays during CPU restriction</link> (jsc#PED-14959)</para>
+      </listitem>
+      <listitem>
        <para>Added section <link xlink:href="index.html#jsc-PED-15000">Increased timeout for installer boot menu</link> (jsc#PED-15000)</para>
       </listitem>
       <listitem>

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -247,6 +247,17 @@ A minor performance overhead (mostly between 2% and 8%) is restricted to schedul
 
 If you encounter performance regressions on scheduling-intensive workloads, you can disable PSI at boot time by passing `psi=0` to the kernel command line.
 
+[#jsc-PED-14959]
+=== Reduced kernel lock delays during CPU restriction
+
+High CPU load can make a container wait when it shares kernel locks.
+Previously, a container with CPU limits could keep a shared kernel lock when the system restricted its CPU usage.
+Because the container kept the lock, other containers had to wait.
+This waiting occurred even if the other containers had no CPU limits.
+The new task-based model changes this behavior.
+The kernel does not restrict a task when the task holds a critical lock.
+This change prevents delays and improves the separation of container workloads.
+
 [#jsc-PED-15892]
 === Coexistence of zlib and zlib-ng libraries
 


### PR DESCRIPTION
This pull request adds a release note to SLES 16.1 documenting the backport of task-based CPU throttling to prevent kernel lock delays under CPU restriction, in compliance with JSC PED-14959.