### PR TITLE
SLES 16.1, SLES for SAP 16.1, SLE Micro 6.3: BPF tooling updated to the latest upstream versions (jsc#PED-14646)

### DIFF
--- a/adoc/micro/release-notes-micro-63-docinfo.xml
+++ b/adoc/micro/release-notes-micro-63-docinfo.xml
@@ -15,6 +15,9 @@
     <revdescription>
      <itemizedlist>
       <listitem>
+       <para>Added section <link xlink:href="index.html#jsc-PED-14646">BPF tooling updated to the latest upstream versions</link> (jsc#PED-14646)</para>
+      </listitem>
+      <listitem>
        <para>Added section <link xlink:href="index.html#jsc-PED-15396">Support for {ranchelemental} 2.x removed</link> (jsc#PED-15396)</para>
       </listitem>
      </itemizedlist>

--- a/adoc/micro/shared.adoc
+++ b/adoc/micro/shared.adoc
@@ -28,6 +28,18 @@ tag::60[]
 tag::61[]
 tag::62[]
 tag::63[]
+[#jsc-PED-14646]
+= BPF tooling updated to the latest upstream versions
+
+This release updates BPF (Berkeley Packet Filter) tooling to the latest upstream versions.
+The following packages are updated:
+
+* `libbpf` to version 1.6.2
+* `bpftool` to version 7.6.0
+* `bpftrace` to version 0.24.1
+
+These updates provide new features and bug fixes.
+
 [#jsc-PED-7936]
 = Extras channel
 

--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -18,6 +18,9 @@
        <para>Added section <link xlink:href="index.html#jsc-PED-14649">Agama installer supports both standard and immutable installation modes</link> (jsc#PED-14649)</para>
       </listitem>
       <listitem>
+       <para>Added section <link xlink:href="index.html#jsc-PED-14646">BPF tooling updated to the latest upstream versions</link> (jsc#PED-14646)</para>
+      </listitem>
+      <listitem>
        <para>Added section <link xlink:href="index.html#jsc-PED-14959">Reduced kernel lock delays during CPU restriction</link> (jsc#PED-14959)</para>
       </listitem>
       <listitem>

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -234,6 +234,19 @@ Key changes and system requirements:
 * Bypassing global per-protocol socket memory accounting is now supported by configuring a network namespace sysctl.
 * See the upstream kernel changelogs from https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.13 through https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.18.
 
+[#jsc-PED-14646]
+=== BPF tooling updated to the latest upstream versions
+
+This release updates BPF (Berkeley Packet Filter) tooling to the latest upstream versions.
+The following packages are updated:
+
+* `libbpf` to version 1.6.2
+* `bpftool` to version 7.6.0
+* `bpftrace` to version 0.24.1
+* `bcc` to version 0.35.0, which includes the new `libbpf-tools` package
+
+These updates provide new features and bug fixes.
+
 [#jsc-PED-15419]
 === Pressure Stall Information (PSI) enabled by default
 

--- a/adoc/slesap/release-notes-slesap-161-docinfo.xml
+++ b/adoc/slesap/release-notes-slesap-161-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xml:id="revhistory" xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-09-02</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Added section <link xlink:href="index.html#jsc-PED-14646">BPF tooling updated to the latest upstream versions</link> (jsc#PED-14646)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-08-17</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/slesap/release-notes-slesap-161.adoc
+++ b/adoc/slesap/release-notes-slesap-161.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version161.adoc[]
 
 = {productname} Release Notes
-:revdate: 2026-08-17
+:revdate: 2026-09-02
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.


### PR DESCRIPTION
This pull request adds release notes for the BPF tooling updates in SLES 16.1, SLES for SAP 16.1, and SLE Micro 6.3 (jsc#PED-14646).