### PR TITLE
SLES 16.0: Add note about OpenMPI support for Gridware Cluster Scheduler (jsc#PED-13377)

### DIFF
--- a/adoc/sles/release-notes-sles-160-docinfo.xml
+++ b/adoc/sles/release-notes-sles-160-docinfo.xml
@@ -15,6 +15,9 @@
      <revdescription>
       <itemizedlist>
        <listitem>
+        <para>Added section <link xlink:href="index.html#jsc-PED-13377">OpenMPI support for Gridware Cluster Scheduler (Grid Engine)</link> (jsc#PED-13377)</para>
+       </listitem>
+       <listitem>
         <para>Added section <link xlink:href="index.html#jsc-PED-13733">New pre-configured SLES for Tomcat cloud image is available</link> (jsc#PED-13733)</para>
        </listitem>
       </itemizedlist>

--- a/adoc/sles/version160.adoc
+++ b/adoc/sles/version160.adoc
@@ -182,6 +182,13 @@ See <<jsc-PED-6311>>.
 // jsc#PED-11656
 * We now provide a unified image that can be used to install either {slesa} or {slessapa}
 
+[#jsc-PED-13377]
+=== OpenMPI support for Gridware Cluster Scheduler (Grid Engine)
+
+OpenMPI now supports the Gridware Cluster Scheduler (Grid Engine) out-of-the-box.
+This update configures OpenMPI packages with the `--with-sge` parameter.
+Previously, OpenMPI only supported the Slurm workload manager out-of-the-box.
+
 [#jsc-PED-13733]
 === New pre-configured SLES for Tomcat cloud image is available
 


### PR DESCRIPTION
Author release note documenting OpenMPI support for Gridware Cluster Scheduler (Grid Engine) in SLES 16.0.