### PR TITLE
SLES 16.1, SLE Micro 6.2: Add note about stable kABI for the real-time kernel (jsc#PED-12998)

### DIFF
--- a/adoc/micro/release-notes-micro-62-docinfo.xml
+++ b/adoc/micro/release-notes-micro-62-docinfo.xml
@@ -15,6 +15,9 @@
     <revdescription>
      <itemizedlist>
       <listitem>
+       <para>Added section <link xlink:href="index.html#jsc-PED-12998">Stable kABI for real-time kernel</link> (jsc#PED-12998)</para>
+      </listitem>
+      <listitem>
        <para>Added section <link xlink:href="index.html#jsc-PED-15447">Reduced set of pre-built immutable system images</link> (jsc#PED-15447)</para>
       </listitem>
      </itemizedlist>

--- a/adoc/micro/version62.adoc
+++ b/adoc/micro/version62.adoc
@@ -29,6 +29,9 @@ include::../shared.adoc[tags=jscped-12879,leveloffset=+3]
 // jsc#PED-15447
 include::../shared.adoc[tags=jscped-15447,leveloffset=+3]
 
+// jsc#PED-12998
+include::../shared.adoc[tags=jscped-12998,leveloffset=+3]
+
 
 [#bsc-1252729]
 ==== Cockpit disabled by default

--- a/adoc/shared.adoc
+++ b/adoc/shared.adoc
@@ -481,3 +481,14 @@ To manage operating system deployments, use {ranchelemental} 3.x.
 The coexistence of versions 2.x and 3.x in the previous release supported the migration path.
 Only {ranchelemental} 3.x remains supported from this release onward.
 end::jscped-15396[]
+
+tag::jscped-12998[]
+[#jsc-PED-12998]
+= Stable kABI for real-time kernel
+
+The real-time kernel (`kernel-rt`) now maintains a stable kernel Application Binary Interface (kABI) during maintenance updates.
+This stability ensures that compatible third-party kernel modules do not require recompilation for every kernel update.
+Note that the real-time kernel and the default kernel do not share a common kABI.
+Therefore, drivers built for the default kernel cannot be used with the real-time kernel and must be built separately.
+While SUSE aims to keep the real-time kABI stable, rare technical requirements might still require changes in future updates.
+end::jscped-12998[]

--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -15,6 +15,9 @@
     <revdescription>
      <itemizedlist>
       <listitem>
+       <para>Added section <link xlink:href="index.html#jsc-PED-12998">Stable kABI for real-time kernel</link> (jsc#PED-12998)</para>
+      </listitem>
+      <listitem>
        <para>Added section <link xlink:href="index.html#jsc-PED-14649">Agama installer supports both standard and immutable installation modes</link> (jsc#PED-14649)</para>
       </listitem>
       <listitem>

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -505,6 +505,9 @@ All system roles now support the real-time kernel.
 This change provides deterministic latency and predictable execution times for standard server installations.
 
 
+include::../shared.adoc[tags=jscped-12998,leveloffset=+2]
+
+
 [#bsc-1261338]
 === RAID configuration not supported in installer Web UI
 


### PR DESCRIPTION
This PR adds a shared release note for the real-time kernel stable kABI (jsc#PED-12998) and includes it in SLES 16.1 and SLE Micro 6.2.