### PR TITLE
SLES 16.1: Drop iptables completely (jsc#PED-12886)

### DIFF
--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -15,6 +15,9 @@
     <revdescription>
      <itemizedlist>
       <listitem>
+       <para>Added section <link xlink:href="index.html#removed">Drop iptables completely in SLFO</link> (jsc#PED-12886)</para>
+      </listitem>
+      <listitem>
        <para>Added section <link xlink:href="index.html#jsc-PED-12998">Stable kABI for real-time kernel</link> (jsc#PED-12998)</para>
       </listitem>
       <listitem>

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -908,6 +908,15 @@ This section lists features and packages that were removed from {productname} or
 
 The following features and packages have been removed in this release.
 
+// jsc#PED-12886
+* The `iptables` and `ipset` packages have been removed from {productname} 16.1.
+  Use `nftables` to manage network packet filtering.
+  To support migration to `nftables`, {productname} 16.1 continues to ship the following translation tools:
+** `iptables-translate`
+** `ip6tables-translate`
+** `ebtables-translate`
+** `arptables-translate`
+
 // jsc#PED-16771
 // bsc#1271307
 * The `python-bleach` package is removed from {productname} 16.1.


### PR DESCRIPTION
Add SLES 16.1 release note about dropping iptables completely in SLFO (PED-12886).