### PR TITLE
SLES 16.1, SLES 16.2: Postpone dropping iptables completely to SLES 16.2 (jsc#PED-12886)

### DIFF
--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -15,9 +15,6 @@
     <revdescription>
      <itemizedlist>
       <listitem>
-       <para>Added section <link xlink:href="index.html#removed">Drop iptables completely in SLFO</link> (jsc#PED-12886)</para>
-      </listitem>
-      <listitem>
        <para>Added section <link xlink:href="index.html#jsc-PED-12998">Stable kABI for real-time kernel</link> (jsc#PED-12998)</para>
       </listitem>
       <listitem>

--- a/adoc/sles/release-notes-sles-162-docinfo.xml
+++ b/adoc/sles/release-notes-sles-162-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-09-02</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Added section <link xlink:href="index.html#removed">Drop iptables completely in SLFO</link> (jsc#PED-12886)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-08-25</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/sles/release-notes-sles-162.adoc
+++ b/adoc/sles/release-notes-sles-162.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version162.adoc[]
 
 = SUSE Linux Enterprise Server Release Notes
-:revdate: 2026-08-25
+:revdate: 2026-09-02
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -908,15 +908,6 @@ This section lists features and packages that were removed from {productname} or
 
 The following features and packages have been removed in this release.
 
-// jsc#PED-12886
-* The `iptables` and `ipset` packages have been removed from {productname} 16.1.
-  Use `nftables` to manage network packet filtering.
-  To support migration to `nftables`, {productname} 16.1 continues to ship the following translation tools:
-** `iptables-translate`
-** `ip6tables-translate`
-** `ebtables-translate`
-** `arptables-translate`
-
 // jsc#PED-16771
 // bsc#1271307
 * The `python-bleach` package is removed from {productname} 16.1.

--- a/adoc/sles/version162.adoc
+++ b/adoc/sles/version162.adoc
@@ -152,6 +152,15 @@ This section lists features and packages that were removed from {productname} or
 
 The following features and packages have been removed in this release.
 
+// jsc#PED-12886
+* The `iptables` and `ipset` packages have been removed from {productname} 16.2.
+  Use `nftables` to manage network packet filtering.
+  To support migration to `nftables`, {productname} 16.2 continues to ship the following translation tools:
+** `iptables-translate`
+** `ip6tables-translate`
+** `ebtables-translate`
+** `arptables-translate`
+
 // jsc#PED-16257
 * The following SSSD features and options have been removed in {productname} 16.2:
 ** The enumeration feature for the AD or IPA provider


### PR DESCRIPTION
Postpone dropping iptables completely to SLES 16.2. This reverts the SLES 16.1 changes and places the release note under SLES 16.2.