### PR TITLE
SLES 16.1: aarch64: Announce Rockchip RK3588

### DIFF
--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -668,7 +668,7 @@ System-on-Chip (SoC) chipsets:
 * {nxpreg} {imx} 8M, 8M{nbsp}Mini; {layerscapereg} LS1012A, LS1027A/LS1017A, LS1028A/LS1018A, LS1043A, LS1046A, LS1088A, LS2080A/LS2040A, LS2088A, LX2160A
 // * {qcomreg} {centriqreg} 2400
 // jsc#PED-16288 (RK3588)
-* Rockchip RK3399, RK3588
+* Rockchip RK3399, *RK3588*
 * {socionextreg} {synquacerreg} SC2A11
 * {xilinxreg} {zynqreg} {ultrascalereg}{nbzwsp}+ MPSoC
 

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -700,6 +700,15 @@ This allows the kernel to log messages atomically and reliably to the console ev
 This ensures critical post-crash details are captured immediately without relying on legacy printing locks or threads.
 
 
+[#jsc-PED-16289]
+=== Rockchip RK3588 driver enablement
+
+{productname} {this-version} contains drivers for booting on Rockchip RK3588 System-on-Chip based platforms.
+
+Not included in this release are display drivers or Neural Processing Unit (NPU) drivers.
+If you need missing drivers for RK3588 or for a different chip from the RK35 family, contact your {suse} representative.
+
+
 [#ibm-z]
 == {ibmz}-specific changes (s390x)
 


### PR DESCRIPTION
* Add a section announcing Rockchip RK3588 SoC enablement
* Mark RK3588 as bold (new)