### PR TITLE
SLE HA 16.1, SLES for SAP 16.1: Add note about upcoming Corosync encryption enforcement and removal of UDP/UDPU (jsc#PED-16430)

### DIFF
--- a/adoc/shared.adoc
+++ b/adoc/shared.adoc
@@ -361,6 +361,21 @@ The old configuration properties are still supported but are marked as deprecate
 * `stop-orphan-actions` is now `cancel-removed-actions`
 end::jscped-15950[]
 
+tag::jscped-16430[]
+[#jsc-PED-16430]
+= Upcoming Corosync encryption enforcement and removal of UDP/UDPU transport
+
+In High Availability 16.2, {corosync} will enforce encryption by default to prevent unauthenticated remote attacks.
+This change will affect the configuration as follows:
+
+* The totem security authentication option (`secauth`) must be `on`.
+Corosync will report an error if `secauth` is not `on`, or if the configuration uses `none` for `crypto_hash` or `crypto_cipher`.
+* {corosync} will use Kronosnet (`knet`) for all transport.
+Corosync will not support `udp` and `udpu` transport options.
+The cluster migration tool will automatically convert existing `udp` or `udpu` configurations to `knet`.
+* The `crm` utility and `crmsh bootstrap` will no longer use the parameters `corosync.totem.crypto_hash` and `corosync.totem.crypto_cipher` in `/etc/crm/profiles.yml`.
+end::jscped-16430[]
+
 tag::bsc1275537[]
 [#bsc-1275537]
 = Deprecation of legacy XFS v4 filesystem format

--- a/adoc/sleha/release-notes-sleha-161-docinfo.xml
+++ b/adoc/sleha/release-notes-sleha-161-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xml:id="revhistory" xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-09-04</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Documented the upcoming Corosync encryption enforcement and removal of UDP/UDPU transport (<link xlink:href="index.html#jsc-PED-16430">jsc#PED-16430</link>)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-09-02</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/sleha/release-notes-sleha-161.adoc
+++ b/adoc/sleha/release-notes-sleha-161.adoc
@@ -2,7 +2,7 @@ include::../common/attributes-generic.adoc[]
 include::attributes.adoc[]
 
 = {productname} Release Notes
-:revdate: 2026-09-02
+:revdate: 2026-09-04
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/sleha/version161.adoc
+++ b/adoc/sleha/version161.adoc
@@ -54,3 +54,5 @@ This section lists features and packages that were removed from {productname} or
 *  `sctp` support has been deprecated in `kronosnet` and to be removed upstream in 2.x
 
 include::../shared.adoc[tags=jscped-15950,leveloffset=+3]
+
+include::../shared.adoc[tags=jscped-16430,leveloffset=+3]

--- a/adoc/slesap/release-notes-slesap-161-docinfo.xml
+++ b/adoc/slesap/release-notes-slesap-161-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xml:id="revhistory" xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-09-04</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Documented the upcoming Corosync encryption enforcement and removal of UDP/UDPU transport (<link xlink:href="index.html#jsc-PED-16430">jsc#PED-16430</link>)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-09-03</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/slesap/release-notes-slesap-161.adoc
+++ b/adoc/slesap/release-notes-slesap-161.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version161.adoc[]
 
 = {productname} Release Notes
-:revdate: 2026-09-03
+:revdate: 2026-09-04
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/slesap/version161.adoc
+++ b/adoc/slesap/version161.adoc
@@ -75,4 +75,6 @@ The following features and packages are deprecated and will be removed in a futu
 
 include::../shared.adoc[tags=jscped-15950,leveloffset=+3]
 
+include::../shared.adoc[tags=jscped-16430,leveloffset=+3]
+
 


### PR DESCRIPTION
This PR adds the deprecation warning for upcoming Corosync encryption enforcement and removal of UDP/UDPU transport in HA 16.2 to the High Availability 16.1 and SLES for SAP 16.1 release notes.