### PR TITLE
SLES 16.2: Disable XFS legacy format (v4) mounts by default (jsc#PED-16898)

### DIFF
--- a/adoc/sles/release-notes-sles-162-docinfo.xml
+++ b/adoc/sles/release-notes-sles-162-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-09-08</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Added section <link xlink:href="index.html#jsc-PED-16898">Legacy XFS v4 format filesystem mounts disabled by default</link> (jsc#PED-16898)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-09-02</date>
     <revdescription>
      <itemizedlist>
@@ -80,9 +90,6 @@
      </itemizedlist>
     </revdescription>
    </revision>
-  <revision>
-    <date>{revdate}</date>
-  </revision>
 </revhistory>
 <meta name="series">Release Notes</meta>
 <meta name="maintainer" content="{maintainer}"/>

--- a/adoc/sles/release-notes-sles-162.adoc
+++ b/adoc/sles/release-notes-sles-162.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version162.adoc[]
 
 = SUSE Linux Enterprise Server Release Notes
-:revdate: 2026-09-02
+:revdate: 2026-09-08
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/sles/version162.adoc
+++ b/adoc/sles/version162.adoc
@@ -107,6 +107,24 @@ There are no technology previews at this time.
 
 == Changes affecting all architectures
 
+[#jsc-PED-16898]
+=== Legacy XFS v4 format filesystem mounts disabled by default
+
+{productname} 16.2 disables legacy XFS v4 format filesystem mounts by default.
+The `xfs` kernel module includes a new parameter that disables these mounts.
+Mounting legacy XFS v4 filesystems fails by default unless this behavior is overridden.
+
+This change can cause boot or upgrade failures if legacy filesystems are present and not migrated before the upgrade.
+To mount legacy XFS v4 filesystems, pass the override parameter to the kernel during boot, or configure the parameter under `/etc/modprobe.d/`.
+
+Migrate existing legacy filesystems to the modern XFS v5 format to ensure future compatibility.
+XFS v5 remains fully supported.
+For details on deprecation and migration steps, see <<bsc-1275537>>.
+
+// bsc#1275537
+include::../shared.adoc[tags=bsc1275537,leveloffset=+2]
+
+
 [#jsc-PED-16669]
 === GNU `patch` updated to version 2.8
 
@@ -193,5 +211,9 @@ Use `mdadm` instead to manage and monitor software RAID devices.
 ////
 
 The following features and packages are deprecated and will be removed in a future version of {productname}.
+
+// bsc#1275537
+* Legacy XFS v4 filesystems are deprecated.
+  For details, see <<bsc-1275537>>.
 
 // ===================================================================


### PR DESCRIPTION
This Pull Request adds SLES 16.2 release notes regarding legacy XFS v4 format mounts being disabled by default. It also includes the shared deprecation note and adds a corresponding changelog entry.