### PR TITLE
SLE Micro 6.2: Remove salt-minion from SLE Micro (jsc#PED-13793)

### DIFF
--- a/adoc/micro/release-notes-micro-62-docinfo.xml
+++ b/adoc/micro/release-notes-micro-62-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-09-08</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Removed `salt-minion` package from raw images and the product repository (jsc#PED-13793)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-09-02</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/micro/release-notes-micro-62.adoc
+++ b/adoc/micro/release-notes-micro-62.adoc
@@ -4,7 +4,7 @@ include::attributes.adoc[]
 :this-version: 6.2
 
 = SL Micro Release Notes
-:revdate: 2026-09-02
+:revdate: 2026-09-08
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/micro/version62.adoc
+++ b/adoc/micro/version62.adoc
@@ -103,6 +103,11 @@ Information in this section applies to {productname} {this-version} on IBM Power
 // [#removed]
 ==== Removed features and packages
 
+// jsc#PED-13793
+* `salt-minion` has been removed from raw images and the product repository.
+{suma} includes its own client tools, which contain the Salt minion.
+Therefore, the operating system does not need to provide `salt-minion`.
+
 * `criu`
 * `yomi` is not supported anymore
 * `nerdctl`


### PR DESCRIPTION
Closes jsc#PED-13793. Removes salt-minion package release note from SLE Micro 6.2 as the package was removed from raw images and product repository.