### PR TITLE
SLE Micro 6.2: Add note about enlarged partition offset on aarch64 (jsc#PED-13142)

### DIFF
--- a/adoc/micro/release-notes-micro-62-docinfo.xml
+++ b/adoc/micro/release-notes-micro-62-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-09-09</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Added note about enlarged partition offset on aarch64 bare-metal images (jsc#PED-13142)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-09-08</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/micro/release-notes-micro-62.adoc
+++ b/adoc/micro/release-notes-micro-62.adoc
@@ -4,7 +4,7 @@ include::attributes.adoc[]
 :this-version: 6.2
 
 = SL Micro Release Notes
-:revdate: 2026-09-08
+:revdate: 2026-09-09
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/micro/version62.adoc
+++ b/adoc/micro/version62.adoc
@@ -85,10 +85,19 @@ include::shared.adoc[tags=62,leveloffset=+3]
 [#aarch64]
 === {arm} 64-bit-specific features and fixes ({aarch64})
 
+include::../kernel-160-aarch64.adoc[leveloffset=+3]
+
+[#aarch64-general]
+==== General changes
+
+// jsc#PED-13142
+* On {aarch64} bare-metal images, the partition offset for the first partition increased from 2 MiB to 4 MiB (8192 sectors).
+This change provides additional disk space for bootloader firmware binaries, such as custom U-Boot binaries with EDK2 UEFI support on {nxpreg} {imx}{nbsp}93 platforms.
+The change only affects bare-metal installation media, such as SD cards and eMMC.
+It does not affect {rpi} or virtual machine (VM) images.
+
 // jsc#PED-13148
 * full-disk encryption is now supported
-
-include::../kernel-160-aarch64.adoc[leveloffset=+3]
 
 [#power]
 === Power-specific changes (ppc64le)


### PR DESCRIPTION
This PR adds the release note for PED-13142 regarding the partition offset increase on aarch64 bare-metal images, and updates corresponding revdate/revhistory.