### PR TITLE
SLES 16.2: Drop yast2-ldap package (jsc#PED-16946)

### DIFF
--- a/adoc/sles/release-notes-sles-162-docinfo.xml
+++ b/adoc/sles/release-notes-sles-162-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-09-10</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Documented removal of yast2-ldap package (<link xlink:href="index.html#removed">jsc#PED-16946</link>)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-09-08</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/sles/release-notes-sles-162.adoc
+++ b/adoc/sles/release-notes-sles-162.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version162.adoc[]
 
 = SUSE Linux Enterprise Server Release Notes
-:revdate: 2026-09-08
+:revdate: 2026-09-10
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/sles/version162.adoc
+++ b/adoc/sles/version162.adoc
@@ -200,6 +200,11 @@ The following features and packages have been removed in this release.
 * The `dmraid` package (Device-Mapper Software RAID Support Tool) has been removed.
 Use `mdadm` instead to manage and monitor software RAID devices.
 
+// jsc#PED-16946
+* {productname} 16.2 removes the `yast2-ldap` package.
+  The package depends on legacy OpenLDAP libraries that are no longer available.
+  Use SSSD to configure LDAP authentication.
+
 
 [#deprecated]
 === Deprecated features and packages


### PR DESCRIPTION
Document the removal of the yast2-ldap package in SLES 16.2 (jsc#PED-16946).