### PR TITLE
SLES 16.1: Document removal of libmsgpack-c2 once required for AMD ROCm (jsc#PED-16850)

### DIFF
--- a/adoc/sles/release-notes-sles-161-docinfo.xml
+++ b/adoc/sles/release-notes-sles-161-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-09-11</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Documented removal of <literal>libmsgpack-c2</literal> package once required for AMD ROCm (<link xlink:href="index.html#removed">jsc#PED-16850</link>)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-09-03</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/sles/release-notes-sles-161.adoc
+++ b/adoc/sles/release-notes-sles-161.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version161.adoc[]
 
 = SUSE Linux Enterprise Server Release Notes
-:revdate: 2026-09-03
+:revdate: 2026-09-11
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/sles/release-notes-sles-162-docinfo.xml
+++ b/adoc/sles/release-notes-sles-162-docinfo.xml
@@ -11,6 +11,16 @@
 <date>{revdate}</date>
 <revhistory xmlns:xlink="http://www.w3.org/1999/xlink">
   <revision>
+    <date>2026-09-11</date>
+    <revdescription>
+     <itemizedlist>
+      <listitem>
+       <para>Documented removal of <literal>libmsgpack-c2</literal> package once required for AMD ROCm (<link xlink:href="index.html#removed">jsc#PED-16850</link>)</para>
+      </listitem>
+     </itemizedlist>
+    </revdescription>
+  </revision>
+  <revision>
     <date>2026-09-10</date>
     <revdescription>
      <itemizedlist>

--- a/adoc/sles/release-notes-sles-162.adoc
+++ b/adoc/sles/release-notes-sles-162.adoc
@@ -3,7 +3,7 @@ include::attributes.adoc[]
 include::attributes-version162.adoc[]
 
 = SUSE Linux Enterprise Server Release Notes
-:revdate: 2026-09-10
+:revdate: 2026-09-11
 :page-revdate: {revdate}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {productname} and important product updates.

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -933,7 +933,7 @@ The following features and packages have been removed in this release.
 // jsc#PED-16850
 * The `libmsgpack-c2` package has been removed from {productname} 16.1.
   This package was previously required to support AMD ROCm, which is no longer planned for {productname}.
-  The package has been relocated to {ph}. (jsc#PED-16850)
+  The package has been relocated to {ph}.
 
 // jsc#PED-16771
 // bsc#1271307

--- a/adoc/sles/version161.adoc
+++ b/adoc/sles/version161.adoc
@@ -930,6 +930,11 @@ This section lists features and packages that were removed from {productname} or
 
 The following features and packages have been removed in this release.
 
+// jsc#PED-16850
+* The `libmsgpack-c2` package has been removed from {productname} 16.1.
+  This package was previously required to support AMD ROCm, which is no longer planned for {productname}.
+  The package has been relocated to {ph}. (jsc#PED-16850)
+
 // jsc#PED-16771
 // bsc#1271307
 * The `python-bleach` package is removed from {productname} 16.1.

--- a/adoc/sles/version162.adoc
+++ b/adoc/sles/version162.adoc
@@ -173,7 +173,7 @@ The following features and packages have been removed in this release.
 // jsc#PED-16850
 * The `libmsgpack-c2` package has been removed from {productname} 16.2.
   This package was previously required to support AMD ROCm, which is no longer planned for {productname}.
-  The package has been relocated to {ph}. (jsc#PED-16850)
+  The package has been relocated to {ph}.
 
 // jsc#PED-12886
 * The `iptables` and `ipset` packages have been removed from {productname} 16.2.

--- a/adoc/sles/version162.adoc
+++ b/adoc/sles/version162.adoc
@@ -170,6 +170,11 @@ This section lists features and packages that were removed from {productname} or
 
 The following features and packages have been removed in this release.
 
+// jsc#PED-16850
+* The `libmsgpack-c2` package has been removed from {productname} 16.2.
+  This package was previously required to support AMD ROCm, which is no longer planned for {productname}.
+  The package has been relocated to {ph}. (jsc#PED-16850)
+
 // jsc#PED-12886
 * The `iptables` and `ipset` packages have been removed from {productname} 16.2.
   Use `nftables` to manage network packet filtering.


### PR DESCRIPTION
This pull request adds a release note for the removal of the libmsgpack-c2 package in SLES 16.1 under the Removed features and packages section. This package was previously required to support AMD ROCm, which is no longer planned for SLES 16.x.